### PR TITLE
ISSUE 19: Error: could not find config file /etc/supervisord.conf

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -56,7 +56,7 @@ if [ ! -d ${CONTAINER_MOUNT_PATH_CONFIG}/ssh ]; then
 fi
 
 if [[ ! -n $(find ${CONTAINER_MOUNT_PATH_CONFIG}/ssh -maxdepth 1 -type f) ]]; then
-       CMD=$(cp -R etc/services-config/ssh/ ${CONTAINER_MOUNT_PATH_CONFIG}/ssh/)
+       CMD=$(cp -R etc/services-config/ssh ${CONTAINER_MOUNT_PATH_CONFIG}/)
        $CMD || sudo $CMD
 fi
 
@@ -66,7 +66,7 @@ if [ ! -d ${CONTAINER_MOUNT_PATH_CONFIG}/supervisor ]; then
 fi
 
 if [[ ! -n $(find ${CONTAINER_MOUNT_PATH_CONFIG}/supervisor -maxdepth 1 -type f) ]]; then
-       CMD=$(cp -R etc/services-config/supervisor/ ${CONTAINER_MOUNT_PATH_CONFIG}/supervisor/)
+       CMD=$(cp -R etc/services-config/supervisor ${CONTAINER_MOUNT_PATH_CONFIG}/)
        $CMD || sudo $CMD
 fi
 


### PR DESCRIPTION
On non Darwin docker hosts the cp -R syntax appears to be different resulting in the supervisor directory being copied into place on first run instead of it's contents.