### PR TITLE
ISSUE 89: Enable PAM by default. Modify sshd_config instead of ADD.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,16 +76,15 @@ RUN sed -i 's~^# %wheel\tALL=(ALL)\tALL~%wheel\tALL=(ALL) ALL~g' /etc/sudoers
 # -----------------------------------------------------------------------------
 ADD etc/ssh-bootstrap /etc/
 ADD etc/services-config/ssh/authorized_keys \
-	etc/services-config/ssh/sshd_config \
 	etc/services-config/ssh/ssh-bootstrap.conf \
 	/etc/services-config/ssh/
 ADD etc/services-config/supervisor/supervisord.conf /etc/services-config/supervisor/
 
-RUN chmod 600 /etc/services-config/ssh/sshd_config \
-	&& chmod +x /etc/ssh-bootstrap \
+RUN cp -pf /etc/ssh/sshd_config /etc/services-config/ssh/ \
 	&& ln -sf /etc/services-config/supervisor/supervisord.conf /etc/supervisord.conf \
 	&& ln -sf /etc/services-config/ssh/sshd_config /etc/ssh/sshd_config \
-	&& ln -sf /etc/services-config/ssh/ssh-bootstrap.conf /etc/ssh-bootstrap.conf
+	&& ln -sf /etc/services-config/ssh/ssh-bootstrap.conf /etc/ssh-bootstrap.conf \
+	&& chmod +x /etc/ssh-bootstrap
 
 # -----------------------------------------------------------------------------
 # Purge

--- a/etc/services-config/ssh/sshd_config
+++ b/etc/services-config/ssh/sshd_config
@@ -93,8 +93,8 @@ GSSAPICleanupCredentials yes
 # If you just want the PAM account and session checks to run without
 # PAM authentication, then enable this but set PasswordAuthentication
 # and ChallengeResponseAuthentication to 'no'.
-UsePAM no
-#UsePAM yes
+#UsePAM no
+UsePAM yes
 
 # Accept locale-related environment variables
 AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES


### PR DESCRIPTION
Relates to: https://github.com/jdeathe/centos-ssh/issues/89