### PR TITLE
ISSUE 139: Use a lock file to stop sshd startup on sshd-boostrap error

### DIFF
--- a/etc/services-config/supervisor/supervisord.d/sshd-bootstrap.conf
+++ b/etc/services-config/supervisor/supervisord.d/sshd-bootstrap.conf
@@ -1,6 +1,6 @@
 [program:sshd-bootstrap]
 priority = 5
-command = bash -c 'env >> /etc/sshd-bootstrap.env; /usr/sbin/sshd-bootstrap'
+command = bash -c 'env >> /etc/sshd-bootstrap.env; /usr/sbin/sshd-bootstrap && rm -f /tmp/sshd.lock'
 startsecs = 0
 startretries = 0
 autorestart = false

--- a/etc/services-config/supervisor/supervisord.d/sshd.conf
+++ b/etc/services-config/supervisor/supervisord.d/sshd.conf
@@ -1,6 +1,6 @@
 [program:sshd]
 priority = 10
-command = bash -c 'sleep 2 && /usr/sbin/sshd -D -e'
+command = bash -c 'touch /tmp/sshd.lock; while [ -e /tmp/sshd.lock ]; do sleep 0.1; done; /usr/sbin/sshd -D -e'
 redirect_stderr = true
 stdout_logfile = /var/log/secure
 stdout_events_enabled = true


### PR DESCRIPTION
Resolves: https://github.com/jdeathe/centos-ssh/issues/139
