### PR TITLE
CLOSES #182: Fixed issue with sshd restart being dependant on sshd-boostrap

### DIFF
--- a/etc/services-config/supervisor/supervisord.d/sshd-bootstrap.conf
+++ b/etc/services-config/supervisor/supervisord.d/sshd-bootstrap.conf
@@ -1,6 +1,6 @@
 [program:sshd-bootstrap]
 priority = 5
-command = bash -c 'env >> /etc/sshd-bootstrap.env; /usr/sbin/sshd-bootstrap && rm -f /tmp/sshd.lock'
+command = bash -c 'touch /tmp/sshd-bootstrap.lock; env >> /etc/sshd-bootstrap.env; /usr/sbin/sshd-bootstrap && rm -f /tmp/sshd-bootstrap.lock'
 startsecs = 0
 startretries = 0
 autorestart = false

--- a/etc/services-config/supervisor/supervisord.d/sshd.conf
+++ b/etc/services-config/supervisor/supervisord.d/sshd.conf
@@ -1,6 +1,7 @@
 [program:sshd]
 priority = 10
-command = bash -c 'touch /tmp/sshd.lock; while [ -e /tmp/sshd.lock ]; do sleep 0.1; done; /usr/sbin/sshd -D -e'
+command = bash -c 'while true; do sleep 0.1; [ -e /tmp/sshd-bootstrap.lock ] || break; done; /usr/sbin/sshd -D -e'
+autorestart = true
 redirect_stderr = true
 stdout_logfile = /var/log/secure
 stdout_events_enabled = true


### PR DESCRIPTION
Resolves: #182 

Patched back CentOS-6 #161
