### PR TITLE
CLOSES #190: Fixed issue with systemd installation failing on CentOS-7

### DIFF
--- a/ssh.pool-1.1.1@2020.service
+++ b/ssh.pool-1.1.1@2020.service
@@ -18,10 +18,10 @@
 
 [Unit]
 Description=CentOS / Supervisor / OpenSSH // pool-1.1.1
-After=etcd2.service
-After=docker.service
 Requires=docker.service
 Requires=etcd2.service
+After=etcd2.service
+After=docker.service
 
 [Service]
 Restart=on-failure

--- a/ssh.pool-1.1.1@2020.service
+++ b/ssh.pool-1.1.1@2020.service
@@ -19,8 +19,8 @@
 [Unit]
 Description=CentOS / Supervisor / OpenSSH // pool-1.1.1
 Requires=docker.service
-Requires=etcd2.service
-After=etcd2.service
+# Requires=etcd2.service
+# After=etcd2.service
 After=docker.service
 
 [Service]
@@ -88,14 +88,16 @@ ExecStartPre=/bin/bash -c \
     fi; \
   fi"
 
-# Remove existing container (and stop if running). This allows it to
-# be re-created on startup but not removed on exit as with --rm.
+# Terminate existing container to allow for redeployment
 ExecStartPre=/bin/bash -c \
   "if [[ -n $(/usr/bin/docker ps -aq --filter \"name=%p\") ]]; then \
+    if [[ -n $(/usr/bin/docker ps -aq --filter \"name=%p\" --filter \"status=paused\") ]]; then \
+      /usr/bin/docker unpause %p; \
+    fi; \
     if [[ -n $(/usr/bin/docker ps -aq --filter \"name=%p\" --filter \"status=running\") ]]; then \
       /usr/bin/docker stop %p; \
     fi; \
-    /usr/bin/docker rm %p; \
+    /usr/bin/docker rm -f %p; \
   fi"
 
 # Startup
@@ -135,10 +137,17 @@ ExecStart=/bin/bash -c \
       ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}; \
   fi"
 
-ExecStartPost=/usr/bin/etcdctl set /services/${SERVICE_UNIT_NAME}/${SERVICE_UNIT_SHARED_GROUP}/${SERVICE_UNIT_LOCAL_ID}.${SERVICE_UNIT_INSTANCE} %H:%i
+# ExecStartPost=/usr/bin/etcdctl \
+#   set \
+#   /services/${SERVICE_UNIT_NAME}/${SERVICE_UNIT_SHARED_GROUP}/${SERVICE_UNIT_LOCAL_ID}.${SERVICE_UNIT_INSTANCE} \
+#   %H:%i
 
+# Shutdown
 ExecStop=/usr/bin/docker stop --time 10 %p
-ExecStopPost=/usr/bin/etcdctl rm /services/${SERVICE_UNIT_NAME}/${SERVICE_UNIT_SHARED_GROUP}/${SERVICE_UNIT_LOCAL_ID}.${SERVICE_UNIT_INSTANCE}
+
+# ExecStopPost=/usr/bin/etcdctl \
+#   rm \
+#   /services/${SERVICE_UNIT_NAME}/${SERVICE_UNIT_SHARED_GROUP}/${SERVICE_UNIT_LOCAL_ID}.${SERVICE_UNIT_INSTANCE}
 
 [Install]
 WantedBy=multi-user.target

--- a/ssh.pool-1.1.1@2020.service
+++ b/ssh.pool-1.1.1@2020.service
@@ -52,7 +52,7 @@ Environment="SSH_USER_SHELL=/bin/bash"
 Environment="SSH_USER_ID=500:500"
 
 # Initialisation: Load image from local storage if available, otherwise pull.
-ExecStartPre=/bin/sudo /bin/bash -c \
+ExecStartPre=/bin/bash -c \
   "if [[ -z $(/usr/bin/docker images -q ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}) ]]; then \
     if [[ -f ${DOCKER_IMAGE_PACKAGE_PATH}/${DOCKER_IMAGE_NAME}.${DOCKER_IMAGE_TAG}.tar.xz ]]; then \
       /usr/bin/xz -dc ${DOCKER_IMAGE_PACKAGE_PATH}/${DOCKER_IMAGE_NAME}.${DOCKER_IMAGE_TAG}.tar.xz | /usr/bin/docker load; \
@@ -62,7 +62,7 @@ ExecStartPre=/bin/sudo /bin/bash -c \
   fi"
 
 # Create a data container for the configuration volume
-ExecStartPre=/bin/sudo /bin/bash -c \
+ExecStartPre=/bin/bash -c \
   "if [[ ${VOLUME_CONFIG_ENABLED} == true ]] && [[ ${VOLUME_CONFIG_NAMED} == true ]]; then \
     if [[ -z $(/usr/bin/docker ps -aq --filter \"name=${VOLUME_CONFIG_NAME}\") ]]; then \
       /usr/bin/docker run \
@@ -90,7 +90,7 @@ ExecStartPre=/bin/sudo /bin/bash -c \
 
 # Remove existing container (and stop if running). This allows it to
 # be re-created on startup but not removed on exit as with --rm.
-ExecStartPre=/bin/sudo /bin/bash -c \
+ExecStartPre=/bin/bash -c \
   "if [[ -n $(/usr/bin/docker ps -aq --filter \"name=%p\") ]]; then \
     if [[ -n $(/usr/bin/docker ps -aq --filter \"name=%p\" --filter \"status=running\") ]]; then \
       /usr/bin/docker stop %p; \
@@ -99,7 +99,7 @@ ExecStartPre=/bin/sudo /bin/bash -c \
   fi"
 
 # Startup
-ExecStart=/bin/sudo /bin/bash -c \
+ExecStart=/bin/bash -c \
   "if [[ -n $(/usr/bin/docker ps -aq --filter \"name=${VOLUME_CONFIG_NAME}\") ]]; then \
     /usr/bin/docker run \
       --name %p \

--- a/ssh.pool-1.1.1@2020.service
+++ b/ssh.pool-1.1.1@2020.service
@@ -1,6 +1,12 @@
 # -----------------------------------------------------------------------------
 # To install:
 #     sudo cp <container-path>/<service-name>@<port>.service /etc/systemd/system/
+#
+#   If not installing to a CoreOS distribution replace etcd2.service 
+#   with etcd.service using:
+#     sudo sed -i -e 's~etcd2.service~etcd.service~g' \
+#       /etc/systemd/system/<service-name>@<port>.service
+#
 #     sudo systemctl daemon-reload
 #     sudo systemctl enable -f /etc/systemd/system/<service-name>@<port>.service
 #
@@ -19,8 +25,8 @@
 [Unit]
 Description=CentOS / Supervisor / OpenSSH // ssh.pool-1.1.1
 Requires=docker.service
-# Requires=etcd2.service
-# After=etcd2.service
+Requires=etcd2.service
+After=etcd2.service
 After=docker.service
 
 [Service]
@@ -137,17 +143,22 @@ ExecStart=/bin/bash -c \
       ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}; \
   fi"
 
-# ExecStartPost=/usr/bin/etcdctl \
-#   set \
-#   /services/${SERVICE_UNIT_NAME}/${SERVICE_UNIT_SHARED_GROUP}/${SERVICE_UNIT_LOCAL_ID}.${SERVICE_UNIT_INSTANCE} \
-#   %H:%i
+# Register service state
+ExecStartPost=/usr/bin/etcdctl \
+  set \
+  /services/${SERVICE_UNIT_NAME}/${SERVICE_UNIT_SHARED_GROUP}/${SERVICE_UNIT_LOCAL_ID}.${SERVICE_UNIT_INSTANCE} \
+  %H:%i
 
 # Shutdown
 ExecStop=/usr/bin/docker stop --time 10 %p
 
-# ExecStopPost=/usr/bin/etcdctl \
-#   rm \
-#   /services/${SERVICE_UNIT_NAME}/${SERVICE_UNIT_SHARED_GROUP}/${SERVICE_UNIT_LOCAL_ID}.${SERVICE_UNIT_INSTANCE}
+# Unregister service state
+ExecStopPost=/bin/bash -c \
+  "if [[ -n $(/usr/bin/etcdctl get /services/${SERVICE_UNIT_NAME}/${SERVICE_UNIT_SHARED_GROUP}/${SERVICE_UNIT_LOCAL_ID}.${SERVICE_UNIT_INSTANCE} &> /dev/null ) ]]; then \
+    /usr/bin/etcdctl \
+      rm \
+      /services/${SERVICE_UNIT_NAME}/${SERVICE_UNIT_SHARED_GROUP}/${SERVICE_UNIT_LOCAL_ID}.${SERVICE_UNIT_INSTANCE}; \
+  fi"
 
 [Install]
 WantedBy=multi-user.target

--- a/ssh.pool-1.1.1@2020.service
+++ b/ssh.pool-1.1.1@2020.service
@@ -91,8 +91,8 @@ ExecStartPre=/bin/sudo /bin/bash -c \
 # Remove existing container (and stop if running). This allows it to
 # be re-created on startup but not removed on exit as with --rm.
 ExecStartPre=/bin/sudo /bin/bash -c \
-  "if [[ -n $(/usr/bin/docker ps -aq --filter "name=%p") ]]; then \
-    if [[ -n $(/usr/bin/docker ps -aq --filter "name=%p" --filter "status=running") ]]; then \
+  "if [[ -n $(/usr/bin/docker ps -aq --filter \"name=%p\") ]]; then \
+    if [[ -n $(/usr/bin/docker ps -aq --filter \"name=%p\" --filter \"status=running\") ]]; then \
       /usr/bin/docker stop %p; \
     fi; \
     /usr/bin/docker rm %p; \
@@ -100,7 +100,7 @@ ExecStartPre=/bin/sudo /bin/bash -c \
 
 # Startup
 ExecStart=/bin/sudo /bin/bash -c \
-  "if [[ -n $(/usr/bin/docker ps -aq --filter "name=${VOLUME_CONFIG_NAME}") ]]; then \
+  "if [[ -n $(/usr/bin/docker ps -aq --filter \"name=${VOLUME_CONFIG_NAME}\") ]]; then \
     /usr/bin/docker run \
       --name %p \
       -p %i:22 \

--- a/ssh.pool-1.1.1@2020.service
+++ b/ssh.pool-1.1.1@2020.service
@@ -64,7 +64,7 @@ ExecStartPre=/bin/sudo /bin/bash -c \
 # Create a data container for the configuration volume
 ExecStartPre=/bin/sudo /bin/bash -c \
   "if [[ ${VOLUME_CONFIG_ENABLED} == true ]] && [[ ${VOLUME_CONFIG_NAMED} == true ]]; then \
-    if [[ -z $(/usr/bin/docker ps -aq --filter "name=${VOLUME_CONFIG_NAME}") ]]; then \
+    if [[ -z $(/usr/bin/docker ps -aq --filter \"name=${VOLUME_CONFIG_NAME}\") ]]; then \
       /usr/bin/docker run \
         --name ${VOLUME_CONFIG_NAME}.tmp \
         ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} \
@@ -79,7 +79,7 @@ ExecStartPre=/bin/sudo /bin/bash -c \
       /usr/bin/docker kill ${VOLUME_CONFIG_NAME}.tmp; \
     fi; \
   elif [[ ${VOLUME_CONFIG_ENABLED} == true ]] && [[ ${VOLUME_CONFIG_NAMED} != true ]]; then \
-    if [[ -z $(/usr/bin/docker ps -aq --filter "name=${VOLUME_CONFIG_NAME}") ]]; then \
+    if [[ -z $(/usr/bin/docker ps -aq --filter \"name=${VOLUME_CONFIG_NAME}\") ]]; then \
       /usr/bin/docker run \
         --name ${VOLUME_CONFIG_NAME} \
         -v /etc/services-config \

--- a/ssh.pool-1.1.1@2020.service
+++ b/ssh.pool-1.1.1@2020.service
@@ -14,7 +14,7 @@
 #     sudo systemctl [start|stop|restart|kill|status] <service-name>@<port>.service
 #
 # Debugging:
-#     journalctl -fn 50 u <service-name>@<port>.service
+#     journalctl -fn 50 -u <service-name>@<port>.service
 #
 # To uninstall:
 #     sudo systemctl disable -f /etc/systemd/system/<service-name>@<port>.service
@@ -23,7 +23,7 @@
 # -----------------------------------------------------------------------------
 
 [Unit]
-Description=CentOS / Supervisor / OpenSSH // ssh.pool-1.1.1
+Description=CentOS / Supervisor / OpenSSH // %p
 Requires=docker.service
 Requires=etcd2.service
 After=etcd2.service
@@ -36,11 +36,6 @@ TimeoutStartSec=1200
 Environment="DOCKER_IMAGE_PACKAGE_PATH=/var/services-packages"
 Environment="DOCKER_IMAGE_NAME=jdeathe/centos-ssh"
 Environment="DOCKER_IMAGE_TAG=centos-7-2.0.1"
-Environment="SERVICE_UNIT_NAME=ssh"
-Environment="SERVICE_UNIT_APP_GROUP=app-1"
-Environment="SERVICE_UNIT_SHARED_GROUP=pool-1"
-Environment="SERVICE_UNIT_LOCAL_ID=1"
-Environment="SERVICE_UNIT_INSTANCE=1"
 Environment="VOLUME_CONFIG_ENABLED=false"
 Environment="VOLUME_CONFIG_NAMED=false"
 Environment="VOLUME_CONFIG_NAME=volume-config.%p"
@@ -143,21 +138,21 @@ ExecStart=/bin/bash -c \
       ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}; \
   fi"
 
-# Register service state
+# Register service
 ExecStartPost=/usr/bin/etcdctl \
   set \
-  /services/${SERVICE_UNIT_NAME}/${SERVICE_UNIT_SHARED_GROUP}/${SERVICE_UNIT_LOCAL_ID}.${SERVICE_UNIT_INSTANCE} \
+  /services/%p \
   %H:%i
 
 # Shutdown
 ExecStop=/usr/bin/docker stop --time 10 %p
 
-# Unregister service state
+# Unregister service
 ExecStopPost=/bin/bash -c \
-  "if [[ -n $(/usr/bin/etcdctl get /services/${SERVICE_UNIT_NAME}/${SERVICE_UNIT_SHARED_GROUP}/${SERVICE_UNIT_LOCAL_ID}.${SERVICE_UNIT_INSTANCE} &> /dev/null ) ]]; then \
+  "if [[ -n $(/usr/bin/etcdctl get /services/%p &> /dev/null ) ]]; then \
     /usr/bin/etcdctl \
       rm \
-      /services/${SERVICE_UNIT_NAME}/${SERVICE_UNIT_SHARED_GROUP}/${SERVICE_UNIT_LOCAL_ID}.${SERVICE_UNIT_INSTANCE}; \
+      /services/%p; \
   fi"
 
 [Install]

--- a/ssh.pool-1.1.1@2020.service
+++ b/ssh.pool-1.1.1@2020.service
@@ -17,7 +17,7 @@
 # -----------------------------------------------------------------------------
 
 [Unit]
-Description=CentOS / Supervisor / OpenSSH // pool-1.1.1
+Description=CentOS / Supervisor / OpenSSH // ssh.pool-1.1.1
 Requires=docker.service
 # Requires=etcd2.service
 # After=etcd2.service

--- a/systemd-install.sh
+++ b/systemd-install.sh
@@ -6,45 +6,47 @@ if [[ ${DIR_PATH} == */* ]] && [[ ${DIR_PATH} != $( pwd ) ]] ; then
 	cd ${DIR_PATH}
 fi
 
+if [[ ${EUID} -ne 0 ]]; then
+	echo "Please run as root."
+	exit 1
+fi
+
 source run.conf
 
 SERVICE_UNIT_LONG_NAME=${SERVICE_UNIT_LONG_NAME:-ssh.pool-1.1.1}
 SERVICE_UNIT_FILE_NAME=${SERVICE_UNIT_FILE_NAME:-${SERVICE_UNIT_LONG_NAME}@2020.service}
 
 # Copy systemd definition into place and enable it.
-sudo cp ${SERVICE_UNIT_FILE_NAME} /etc/systemd/system/
-sudo systemctl daemon-reload
-sudo systemctl enable -f /etc/systemd/system/${SERVICE_UNIT_FILE_NAME}
+cp ${SERVICE_UNIT_FILE_NAME} /etc/systemd/system/
+systemctl daemon-reload
+systemctl enable -f /etc/systemd/system/${SERVICE_UNIT_FILE_NAME}
 
 # Stop the service and remove containers.
-sudo systemctl stop ${SERVICE_UNIT_FILE_NAME} &> /dev/null
+systemctl stop ${SERVICE_UNIT_FILE_NAME} &> /dev/null
 
 # Terminate the container(s)
-sudo docker rm -f volume-config.${SERVICE_UNIT_LONG_NAME} &> /dev/null
-sudo docker rm -f ${SERVICE_UNIT_LONG_NAME} &> /dev/null
+docker rm -f volume-config.${SERVICE_UNIT_LONG_NAME} &> /dev/null
+docker rm -f ${SERVICE_UNIT_LONG_NAME} &> /dev/null
 
 printf -- "---> Installing %s\n" ${SERVICE_UNIT_FILE_NAME}
-sudo systemctl start ${SERVICE_UNIT_FILE_NAME} &
+systemctl start ${SERVICE_UNIT_FILE_NAME} &
 PIDS[0]=${!}
-PIDS[1]=$(ps --ppid ${PIDS[0]} -o pid=)
 
 # Tail the systemd unit logs unitl installation completes
-sudo journalctl -fu ${SERVICE_UNIT_FILE_NAME} &
-PIDS[2]=${!}
-PIDS[3]=$(ps --ppid ${PIDS[2]} -o pid=)
+journalctl -fu ${SERVICE_UNIT_FILE_NAME} &
+PIDS[1]=${!}
 
 # Wait for installtion to complete
-[[ -n ${PIDS[1]} ]] && wait ${PIDS[1]}
 [[ -n ${PIDS[0]} ]] && wait ${PIDS[0]}
 
 # Allow time for the container bootstrap to complete
 sleep 5
-sudo kill -15 ${PIDS[2]} ${PIDS[3]}
+kill -15 ${PIDS[1]}
 
-if sudo systemctl -q is-active ${SERVICE_UNIT_FILE_NAME}; then
+if systemctl -q is-active ${SERVICE_UNIT_FILE_NAME}; then
 	printf -- " ---> %s\n${COLOUR_POSITIVE} --->${COLOUR_RESET} %s\n" ${SERVICE_UNIT_FILE_NAME} 'Install complete'
 else
 	printf -- "\nService status:\n"
-	sudo systemctl status -l ${SERVICE_UNIT_FILE_NAME}
+	systemctl status -l ${SERVICE_UNIT_FILE_NAME}
 	printf -- "\n${COLOUR_NEGATIVE} --->${COLOUR_RESET} %s\n" 'Install error'
 fi

--- a/systemd-install.sh
+++ b/systemd-install.sh
@@ -13,11 +13,46 @@ fi
 
 source run.conf
 
+is_coreos_distribution ()
+{
+	if [[ -n $( [[ -e /etc/os-release ]] && grep ^ID=coreos$ /etc/os-release ) ]]; then
+		return 0
+	fi
+
+	return 1
+}
+
+replace_etcd_service_name ()
+{
+	local FILE_PATH=${1}
+
+	if [[ -z ${FILE_PATH} ]]; then
+		echo "Path to the service's unit file is required."
+		return 1
+	fi
+
+	if ! [[ -s ${FILE_PATH} ]]; then
+		echo "Unit file not found."
+		return 1
+	fi
+
+	# CoreOS uses etcd.service and etcd2.service for version 1 and 2 of ETCD 
+	# respectively but has both available. Use etcd2.service in the systemd 
+	# unit file and rename for other distributions where etcd.service is the 
+	# only name used.
+	if ! is_coreos_distribution; then
+		echo "---> Not a CoreOS distribution."
+		echo " ---> Renaming etcd2.service to etcd.service in unit file."
+		sed -i -e 's~etcd2.service~etcd.service~g' ${FILE_PATH}
+	fi
+}
+
 SERVICE_UNIT_LONG_NAME=${SERVICE_UNIT_LONG_NAME:-ssh.pool-1.1.1}
 SERVICE_UNIT_FILE_NAME=${SERVICE_UNIT_FILE_NAME:-${SERVICE_UNIT_LONG_NAME}@2020.service}
 
 # Copy systemd definition into place and enable it.
 cp ${SERVICE_UNIT_FILE_NAME} /etc/systemd/system/
+replace_etcd_service_name /etc/systemd/system/${SERVICE_UNIT_FILE_NAME}
 systemctl daemon-reload
 systemctl enable -f /etc/systemd/system/${SERVICE_UNIT_FILE_NAME}
 


### PR DESCRIPTION
Resolves: #190 
- Remove sudo from within scripts that should be run with root privileges.
- Documented manual steps required to run on distributions other than CoreOS and updated the systemd-install.sh script to do this automatically.
- Added handling for terminating a container that's in a `paused` state.
- Use simpler key names for etcd /services/ - using subdirectories seemed like a good idea previously but appears unnecessary.

//TODO: Fixed the issue with installation errors but have identified a few changes that could improve this:
- Split out the service registration part into a separate unit file.
- Rename to be a unit file template so that it can be used to create instances from it.
- Add installation script/steps for installing via [fleet](https://github.com/coreos/fleet).
