### PR TITLE
CLOSES #219: Fixed issues with make errors.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,9 +214,11 @@ ps: prerequisites require-docker-container
 	@ $(docker) ps -as --filter "name=$(DOCKER_NAME)";
 
 require-docker-container:
-ifeq ($(shell $(docker) ps -aq --filter "name=$(DOCKER_NAME)"),)
-	$(error "This operation requires the $(DOCKER_NAME) docker container. Install it with: make install")
-endif
+	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
+			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container."; \
+			echo "$(PREFIX_SUB_STEP) Try Install it with: make install"; \
+			exit 1; \
+		fi
 
 require-docker-image-tag:
 ifeq ($(IS_DOCKER_IMAGE_TAG),)

--- a/Makefile
+++ b/Makefile
@@ -292,18 +292,16 @@ start: prerequisites require-docker-container
 			exit 1; \
 		fi
 
-stop: prerequisites
+stop: prerequisites require-docker-container
 	@ echo "$(PREFIX_STEP) Stopping container"
-	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]] \
-			&& [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
+	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
 			$(docker) stop $(DOCKER_NAME) 1> /dev/null; \
-		fi;
-	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]] \
-			&& [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=exited") ]]; then \
-			echo "$(PREFIX_SUB_STEP_POSITIVE) Container stopped"; \
-		else \
-			echo "$(PREFIX_SUB_STEP_NEGATIVE) Error stopping container"; \
-			exit 1; \
+			if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=exited") ]]; then \
+				echo "$(PREFIX_SUB_STEP_POSITIVE) Container stopped"; \
+			else \
+				echo "$(PREFIX_SUB_STEP_NEGATIVE) Error stopping container"; \
+				exit 1; \
+			fi; \
 		fi
 
 terminate: prerequisites

--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,6 @@ xz := $(shell type -p xz)
 # Used to test docker host is accessible
 get-docker-info := $(shell $(docker) info)
 
-# Tag validation
-IS_DOCKER_IMAGE_TAG := $(shell if [[ $(DOCKER_IMAGE_TAG) =~ $(DOCKER_IMAGE_TAG_PATTERN) ]]; then echo $(DOCKER_IMAGE_TAG); else echo ''; fi)
-IS_DOCKER_RELEASE_TAG := $(shell if [[ $(DOCKER_IMAGE_TAG) =~ $(DOCKER_IMAGE_RELEASE_TAG_PATTERN) ]]; then echo $(DOCKER_IMAGE_TAG); else echo ''; fi)
-
 # Common parameters of create and run targets
 define DOCKER_CONTAINER_PARAMETERS
 --name $(DOCKER_NAME) \
@@ -216,19 +212,22 @@ ps: prerequisites require-docker-container
 require-docker-container:
 	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
 			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container."; \
-			echo "$(PREFIX_SUB_STEP) Try Install it with: make install"; \
+			echo "$(PREFIX_SUB_STEP) Try installing it with: make install"; \
 			exit 1; \
 		fi
 
 require-docker-image-tag:
-ifeq ($(IS_DOCKER_IMAGE_TAG),)
-	$(error "Invalid DOCKER_IMAGE_TAG value $(DOCKER_IMAGE_TAG).")
-endif
+	@ if [[ -z $$(if [[ $(DOCKER_IMAGE_TAG) =~ $(DOCKER_IMAGE_TAG_PATTERN) ]]; then echo $(DOCKER_IMAGE_TAG); else echo ''; fi) ]]; then \
+			echo "$(PREFIX_STEP_NEGATIVE) Invalid DOCKER_IMAGE_TAG value: $(DOCKER_IMAGE_TAG)"; \
+			exit 1; \
+		fi
 
 require-docker-release-tag:
-ifeq ($(IS_DOCKER_RELEASE_TAG),)
-	$(error "Invalid DOCKER_IMAGE_TAG value $(DOCKER_IMAGE_TAG). A release tag is required for this operation.")
-endif
+	@ if [[ -z $$(if [[ $(DOCKER_IMAGE_TAG) =~ $(DOCKER_IMAGE_RELEASE_TAG_PATTERN) ]]; then echo $(DOCKER_IMAGE_TAG); else echo ''; fi) ]]; then \
+			echo "$(PREFIX_STEP_NEGATIVE) Invalid DOCKER_IMAGE_TAG value: $(DOCKER_IMAGE_TAG)"; \
+			echo "$(PREFIX_SUB_STEP) A release tag is required for this operation."; \
+			exit 1; \
+		fi
 
 restart: prerequisites require-docker-container
 	@ echo "$(PREFIX_STEP) Restarting container"
@@ -236,18 +235,18 @@ restart: prerequisites require-docker-container
 	@ echo "$(PREFIX_SUB_STEP_POSITIVE) Container restarted"
 
 rm: prerequisites
-ifneq ($(shell $(docker) ps -aq --filter "name=$(DOCKER_NAME)"),)
-	@ echo "$(PREFIX_STEP) Removing container"; \
-		$(docker) rm -f $(DOCKER_NAME); \
-		if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
-				echo "$(PREFIX_SUB_STEP_POSITIVE) Container removed"; \
+	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
+			echo "$(PREFIX_STEP) Container removal skipped"; \
 		else \
-			echo "$(PREFIX_SUB_STEP_NEGATIVE) Container removal failed"; \
-			exit 1; \
+		  echo "$(PREFIX_STEP) Removing container"; \
+			$(docker) rm -f $(DOCKER_NAME); \
+			if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
+					echo "$(PREFIX_SUB_STEP_POSITIVE) Container removed"; \
+			else \
+				echo "$(PREFIX_SUB_STEP_NEGATIVE) Container removal failed"; \
+				exit 1; \
+			fi; \
 		fi
-else
-	@ echo "$(PREFIX_STEP) Container removal skipped"
-endif
 
 rmi: prerequisites require-docker-image-tag
 	@ if [[ -n $$( if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi; ) ]]; then \
@@ -308,29 +307,29 @@ stop: prerequisites
 		fi
 
 terminate: prerequisites
-ifneq ($(shell $(docker) ps -aq --filter "name=$(DOCKER_NAME)"),)
-	@ echo "$(PREFIX_STEP) Terminating container"
-	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=paused") ]]; then \
-			echo "$(PREFIX_SUB_STEP) Unpausing container"; \
-			$(docker) unpause $(DOCKER_NAME) 1> /dev/null; \
-		fi
-	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
-			echo "$(PREFIX_SUB_STEP) Stopping container"; \
-			$(docker) stop $(DOCKER_NAME) 1> /dev/null; \
-		fi
-	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
-			echo "$(PREFIX_SUB_STEP) Removing container"; \
-			$(docker) rm -f $(DOCKER_NAME) 1> /dev/null; \
-		fi
 	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
-			echo "$(PREFIX_SUB_STEP_POSITIVE) Container terminated"; \
+			echo "$(PREFIX_STEP) Container termination skipped"; \
 		else \
-			echo "$(PREFIX_SUB_STEP_NEGATIVE) Container termination failed"; \
-			exit 1; \
+			echo "$(PREFIX_STEP) Terminating container"; \
+			if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=paused") ]]; then \
+				echo "$(PREFIX_SUB_STEP) Unpausing container"; \
+				$(docker) unpause $(DOCKER_NAME) 1> /dev/null; \
+			fi; \
+			if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
+				echo "$(PREFIX_SUB_STEP) Stopping container"; \
+				$(docker) stop $(DOCKER_NAME) 1> /dev/null; \
+			fi; \
+			if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
+				echo "$(PREFIX_SUB_STEP) Removing container"; \
+				$(docker) rm -f $(DOCKER_NAME) 1> /dev/null; \
+			fi; \
+			if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
+				echo "$(PREFIX_SUB_STEP_POSITIVE) Container terminated"; \
+			else \
+				echo "$(PREFIX_SUB_STEP_NEGATIVE) Container termination failed"; \
+				exit 1; \
+			fi; \
 		fi
-else
-	@ echo "$(PREFIX_STEP) Container termination skipped"
-endif
 
 unpause: prerequisites require-docker-container
 	@ echo "$(PREFIX_STEP) Unpausing container"

--- a/Makefile
+++ b/Makefile
@@ -57,11 +57,18 @@ endef
 	images \
 	load \
 	logs \
+	logs-delayed \
 	pause \
 	prerequisites \
 	pull \
 	ps \
 	require-docker-container \
+	require-docker-container-not \
+	require-docker-container-not-status-paused \
+	require-docker-container-status-created \
+	require-docker-container-status-exited \
+	require-docker-container-status-paused \
+	require-docker-container-status-running \
 	require-docker-image-tag \
 	require-docker-release-tag \
 	restart \
@@ -94,7 +101,7 @@ build: prerequisites require-docker-image-tag
 
 clean: prerequisites | terminate rmi
 
-create: prerequisites
+create: prerequisites require-docker-container-not
 	@ echo "$(PREFIX_STEP) Creating container"
 	@ set -x; \
 		$(docker) create \
@@ -162,6 +169,10 @@ install: | prerequisites terminate create
 logs: prerequisites
 	@ $(docker) logs $(DOCKER_NAME)
 
+logs-delayed: prerequisites
+	@ sleep 3
+	@ $(MAKE) logs
+
 load: prerequisites require-docker-release-tag
 	@ echo "$(PREFIX_STEP) Loading image from package"; \
 		echo "$(PREFIX_SUB_STEP) Package path: $(PACKAGE_PATH)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
@@ -176,7 +187,7 @@ load: prerequisites require-docker-release-tag
 			echo "$(PREFIX_SUB_STEP_POSITIVE) Image loaded"; \
 		fi
 
-pause: prerequisites require-docker-container
+pause: prerequisites require-docker-container-status-running
 	@ echo "$(PREFIX_STEP) Pausing container"
 	@ $(docker) pause $(DOCKER_NAME) 1> /dev/null
 	@ echo "$(PREFIX_SUB_STEP_POSITIVE) Container paused"
@@ -216,6 +227,48 @@ require-docker-container:
 			exit 1; \
 		fi
 
+require-docker-container-not:
+	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
+			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container be removed (or renamed)."; \
+			echo "$(PREFIX_SUB_STEP) Try removing it with: make rm"; \
+			exit 1; \
+		fi
+
+require-docker-container-not-status-paused:
+	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=paused") ]]; then \
+			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container to be unpaused."; \
+			echo "$(PREFIX_SUB_STEP) Try unpausing it with: make unpause"; \
+			exit 1; \
+		fi
+
+require-docker-container-status-created:
+	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=created") ]]; then \
+			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container to be created."; \
+			echo "$(PREFIX_SUB_STEP) Try installing it with: make install"; \
+			exit 1; \
+		fi
+
+require-docker-container-status-exited:
+	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=exited") ]]; then \
+			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container to be exited."; \
+			echo "$(PREFIX_SUB_STEP) Try stopping it with: make stop"; \
+			exit 1; \
+		fi
+
+require-docker-container-status-paused:
+	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=paused") ]]; then \
+			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container to be paused."; \
+			echo "$(PREFIX_SUB_STEP) Try pausing it with: make pause"; \
+			exit 1; \
+		fi
+
+require-docker-container-status-running:
+	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
+			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container to be running."; \
+			echo "$(PREFIX_SUB_STEP) Try starting it with: make start"; \
+			exit 1; \
+		fi
+
 require-docker-image-tag:
 	@ if [[ -z $$(if [[ $(DOCKER_IMAGE_TAG) =~ $(DOCKER_IMAGE_TAG_PATTERN) ]]; then echo $(DOCKER_IMAGE_TAG); else echo ''; fi) ]]; then \
 			echo "$(PREFIX_STEP_NEGATIVE) Invalid DOCKER_IMAGE_TAG value: $(DOCKER_IMAGE_TAG)"; \
@@ -229,12 +282,12 @@ require-docker-release-tag:
 			exit 1; \
 		fi
 
-restart: prerequisites require-docker-container
+restart: prerequisites require-docker-container require-docker-container-not-status-paused
 	@ echo "$(PREFIX_STEP) Restarting container"
 	@ $(docker) restart $(DOCKER_NAME) 1> /dev/null
 	@ echo "$(PREFIX_SUB_STEP_POSITIVE) Container restarted"
 
-rm: prerequisites
+rm: prerequisites require-docker-container-not-status-paused
 	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
 			echo "$(PREFIX_STEP) Container removal skipped"; \
 		else \
@@ -248,7 +301,7 @@ rm: prerequisites
 			fi; \
 		fi
 
-rmi: prerequisites require-docker-image-tag
+rmi: prerequisites require-docker-image-tag require-docker-container-not
 	@ if [[ -n $$( if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi; ) ]]; then \
 			echo "$(PREFIX_STEP) Untagging image"; \
 			echo "$(PREFIX_SUB_STEP) $$( if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi; ) : $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)"; \
@@ -279,7 +332,7 @@ run: prerequisites require-docker-image-tag
 			exit 1; \
 		fi
 
-start: prerequisites require-docker-container 
+start: prerequisites require-docker-container require-docker-container-not-status-paused
 	@ echo "$(PREFIX_STEP) Starting container"
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]] \
 			&& [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
@@ -292,7 +345,7 @@ start: prerequisites require-docker-container
 			exit 1; \
 		fi
 
-stop: prerequisites require-docker-container
+stop: prerequisites require-docker-container-not-status-paused require-docker-container-status-running
 	@ echo "$(PREFIX_STEP) Stopping container"
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
 			$(docker) stop $(DOCKER_NAME) 1> /dev/null; \
@@ -329,7 +382,7 @@ terminate: prerequisites
 			fi; \
 		fi
 
-unpause: prerequisites require-docker-container
+unpause: prerequisites require-docker-container-status-paused
 	@ echo "$(PREFIX_STEP) Unpausing container"
 	@ $(docker) unpause $(DOCKER_NAME) 1> /dev/null
 	@ echo "$(PREFIX_SUB_STEP_POSITIVE) Container unpaused"


### PR DESCRIPTION
Resolves #219 
- Fixed issues with errors thrown by Make on a clean system when first running `make all` or when running `make all` after `make clean`.
- Added `male logs-delayed` to allow logs to be viewed as part of chained targets. e.g. `make all logs-delayed` will perform build, install, start, status and logs operations. If using the standard `make logs` in a chain the container process hasn't had time to complete so logs are incomplete.

The Makefile now replaces the [build.sh](https://github.com/jdeathe/centos-ssh/blob/2.0.1/build.sh) and [run.sh](https://github.com/jdeathe/centos-ssh/blob/2.0.1/run.sh) helper scripts which are now `DEPRECATED` and will be removed in a future release. 
## Usage

The default target is `build` so running make will build the latest tag locally from the Dockerfile. On a clean environment, using the standard form of `make install` will create the docker image and `make start` will start it running and `make stop` will stop the container.

```
$ make
$ make install
$ make start
```
### Build, show the image details, create and start the default example container and view the container process details:

```
$ make build images install start ps
```

Or simply...

```
$ make all
```
### Check the running containers logs

```
$ make logs
```
### Destroy the container

```
$ make terminate
```
### Clean up (untag) the image and to allow a full rebuild

```
$ make clean
```
### Work with an alternative image tag (e.g. a release tag)

Pull the centos-7-2.0.1 tag, display the image details, terminate and run the container then display the container process details. After startup display the logs.

```
$ DOCKER_IMAGE_TAG=centos-7-2.0.1 \
  make pull images terminate run ps logs-delayed
```
### SFTP Mode - quick example

```
$ DOCKER_IMAGE_TAG=centos-7 \
  DOCKER_NAME=sftp.pool-1.1.1 \
  DOCKER_PORT_MAP_TCP_22=2021 \
  SSH_USER_FORCE_SFTP=true \
  make terminate run ps logs-delayed
```
