### PR TITLE
CLOSES #227: Updated CentOS-7 packages sudo and openssh.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,10 @@ RUN rpm --rebuilddb \
 	epel-release \
 	https://centos7.iuscommunity.org/ius-release.rpm \
 	vim-minimal-7.4.160-1.el7 \
-	sudo-1.8.6p7-16.el7 \
-	openssh-6.6.1p1-23.el7_2 \
-	openssh-server-6.6.1p1-23.el7_2 \
-	openssh-clients-6.6.1p1-23.el7_2 \
+	sudo-1.8.6p7-17.el7_2 \
+	openssh-6.6.1p1-25.el7_2 \
+	openssh-server-6.6.1p1-25.el7_2 \
+	openssh-clients-6.6.1p1-25.el7_2 \
 	python-setuptools-0.9.8-4.el7 \
 	yum-plugin-versionlock-1.1.31-34.el7 \
 	&& yum versionlock add \


### PR DESCRIPTION
Resolves: #227
- sudo: 1.8.6p7-16.el7 => 1.8.6p7-17.el7_2
- openssh: 6.6.1p1-23.el7_2 => 6.6.1p1-25.el7_2
