### PR TITLE
CLOSES #235: Handle docker port mappings using IP address or empty string.

### DIFF
--- a/ssh.pool-1@.service
+++ b/ssh.pool-1@.service
@@ -126,7 +126,16 @@ ExecStart=/bin/bash -c \
   "if [[ -n $(/usr/bin/docker ps -aq --filter \"name=${VOLUME_CONFIG_NAME}\") ]]; then \
     exec /usr/bin/docker run \
       --name %p.%i \
-      -p $(( ${DOCKER_PORT_MAP_TCP_22} + $(/usr/bin/awk -F. '$0=$1' <<< %i) - 1 )):22 \
+      --publish $(\
+        if [[ -n $(/usr/bin/gawk 'match($0, /^([0-9]+.[0-9]+.[0-9]+.[0-9]+:)?([0-9]+)$/, matches) { print matches[2]; }' <<< \"${DOCKER_PORT_MAP_TCP_22}\") ]]; then \
+          printf -- '%%s%%s' \
+            \"$(/usr/bin/gawk 'match($0, /^([0-9]+.[0-9]+.[0-9]+.[0-9]+:)?([0-9]+)$/, matches) { print matches[1]; }' <<< "${DOCKER_PORT_MAP_TCP_22}")\" \
+            \"$(( $(/usr/bin/gawk 'match($0, /^([0-9]+.[0-9]+.[0-9]+.[0-9]+:)?([0-9]+)$/, matches) { print matches[2]; }' <<< "${DOCKER_PORT_MAP_TCP_22}") + $(/usr/bin/awk -F. '$0=$1' <<< %i) - 1))\"; \
+        else \
+          printf -- '%%s' \
+            \"${DOCKER_PORT_MAP_TCP_22}\"; \
+        fi; \
+      ):22 \
       --env \"SSH_AUTHORIZED_KEYS=${SSH_AUTHORIZED_KEYS}\" \
       --env \"SSH_AUTOSTART_SSHD=${SSH_AUTOSTART_SSHD}\" \
       --env \"SSH_AUTOSTART_SSHD_BOOTSTRAP=${SSH_AUTOSTART_SSHD_BOOTSTRAP}\" \
@@ -145,7 +154,16 @@ ExecStart=/bin/bash -c \
   else \
     exec /usr/bin/docker run \
       --name %p.%i \
-      -p $(( ${DOCKER_PORT_MAP_TCP_22} + $(/usr/bin/awk -F. '$0=$1' <<< %i) - 1 )):22 \
+      --publish $(\
+        if [[ -n $(/usr/bin/gawk 'match($0, /^([0-9]+.[0-9]+.[0-9]+.[0-9]+:)?([0-9]+)$/, matches) { print matches[2]; }' <<< \"${DOCKER_PORT_MAP_TCP_22}\") ]]; then \
+          printf -- '%%s%%s' \
+            \"$(/usr/bin/gawk 'match($0, /^([0-9]+.[0-9]+.[0-9]+.[0-9]+:)?([0-9]+)$/, matches) { print matches[1]; }' <<< "${DOCKER_PORT_MAP_TCP_22}")\" \
+            \"$(( $(/usr/bin/gawk 'match($0, /^([0-9]+.[0-9]+.[0-9]+.[0-9]+:)?([0-9]+)$/, matches) { print matches[2]; }' <<< "${DOCKER_PORT_MAP_TCP_22}") + $(/usr/bin/awk -F. '$0=$1' <<< %i) - 1))\"; \
+        else \
+          printf -- '%%s' \
+            \"${DOCKER_PORT_MAP_TCP_22}\"; \
+        fi; \
+      ):22 \
       --env \"SSH_AUTHORIZED_KEYS=${SSH_AUTHORIZED_KEYS}\" \
       --env \"SSH_AUTOSTART_SSHD=${SSH_AUTOSTART_SSHD}\" \
       --env \"SSH_AUTOSTART_SSHD_BOOTSTRAP=${SSH_AUTOSTART_SSHD_BOOTSTRAP}\" \


### PR DESCRIPTION
Resolves #235 

Docker port mappings set using the `--publish` parameter can be of the form:

```
[{ip-address}:][{docker-host-port}]:{container-exposed-port}
```

As such, `DOCKER_PORT_MAP_TCP_22` now accepts and correctly handles an empty string for the `{docker-host-port}` value.

_Note:_ Port ranges, `{docker-host-port-start}-{docker-host-port-end}` are not currently supported.
