### PR TITLE
CLOSES #263: Quote port mapping variables + update regex for IP pattern

### DIFF
--- a/ssh.pool-1@.service
+++ b/ssh.pool-1@.service
@@ -127,10 +127,10 @@ ExecStart=/bin/bash -c \
     exec /usr/bin/docker run \
       --name %p.%i \
       --publish $(\
-        if [[ -n $(/usr/bin/gawk 'match($0, /^([0-9]+.[0-9]+.[0-9]+.[0-9]+:)?([0-9]+)$/, matches) { print matches[2]; }' <<< ${DOCKER_PORT_MAP_TCP_22}) ]]; then \
+        if [[ -n $(/usr/bin/gawk 'match($0, /^([0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}:)?([0-9]+)$/, matches) { print matches[2]; }' <<< \"${DOCKER_PORT_MAP_TCP_22}\") ]]; then \
           printf -- '%%s%%s' \
-            \"$(/usr/bin/gawk 'match($0, /^([0-9]+.[0-9]+.[0-9]+.[0-9]+:)?([0-9]+)$/, matches) { print matches[1]; }' <<< \"${DOCKER_PORT_MAP_TCP_22}\")\" \
-            \"$(( $(/usr/bin/gawk 'match($0, /^([0-9]+.[0-9]+.[0-9]+.[0-9]+:)?([0-9]+)$/, matches) { print matches[2]; }' <<< \"${DOCKER_PORT_MAP_TCP_22}\") + $(/usr/bin/awk -F. '$0=$1' <<< %i) - 1 ))\"; \
+            \"$(/usr/bin/gawk 'match($0, /^([0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}:)?([0-9]+)$/, matches) { print matches[1]; }' <<< \"${DOCKER_PORT_MAP_TCP_22}\")\" \
+            \"$(( $(/usr/bin/gawk 'match($0, /^([0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}:)?([0-9]+)$/, matches) { print matches[2]; }' <<< \"${DOCKER_PORT_MAP_TCP_22}\") + $(/usr/bin/awk -F. '$0=$1' <<< %i) - 1 ))\"; \
         else \
           printf -- '%%s' \
             \"${DOCKER_PORT_MAP_TCP_22}\"; \
@@ -155,10 +155,10 @@ ExecStart=/bin/bash -c \
     exec /usr/bin/docker run \
       --name %p.%i \
       --publish $(\
-        if [[ -n $(/usr/bin/gawk 'match($0, /^([0-9]+.[0-9]+.[0-9]+.[0-9]+:)?([0-9]+)$/, matches) { print matches[2]; }' <<< ${DOCKER_PORT_MAP_TCP_22}) ]]; then \
+        if [[ -n $(/usr/bin/gawk 'match($0, /^([0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}:)?([0-9]+)$/, matches) { print matches[2]; }' <<< \"${DOCKER_PORT_MAP_TCP_22}\") ]]; then \
           printf -- '%%s%%s' \
-            \"$(/usr/bin/gawk 'match($0, /^([0-9]+.[0-9]+.[0-9]+.[0-9]+:)?([0-9]+)$/, matches) { print matches[1]; }' <<< \"${DOCKER_PORT_MAP_TCP_22}\")\" \
-            \"$(( $(/usr/bin/gawk 'match($0, /^([0-9]+.[0-9]+.[0-9]+.[0-9]+:)?([0-9]+)$/, matches) { print matches[2]; }' <<< \"${DOCKER_PORT_MAP_TCP_22}\") + $(/usr/bin/awk -F. '$0=$1' <<< %i) - 1 ))\"; \
+            \"$(/usr/bin/gawk 'match($0, /^([0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}:)?([0-9]+)$/, matches) { print matches[1]; }' <<< \"${DOCKER_PORT_MAP_TCP_22}\")\" \
+            \"$(( $(/usr/bin/gawk 'match($0, /^([0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}:)?([0-9]+)$/, matches) { print matches[2]; }' <<< \"${DOCKER_PORT_MAP_TCP_22}\") + $(/usr/bin/awk -F. '$0=$1' <<< %i) - 1 ))\"; \
         else \
           printf -- '%%s' \
             \"${DOCKER_PORT_MAP_TCP_22}\"; \


### PR DESCRIPTION
Resolves #263 

Can now set `DOCKER_PORT_MAP_TCP_22` to an empty string to allow docker to auto-assign a port.
