### PR TITLE
CLOSES #260: Update to source from CentOS-6 6.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,9 @@ RUN rpm --rebuilddb \
 	https://centos6.iuscommunity.org/ius-release.rpm \
 	vim-minimal-7.4.629-5.el6 \
 	sudo-1.8.6p3-24.el6 \
-	openssh-5.3p1-117.el6 \
-	openssh-server-5.3p1-117.el6 \
-	openssh-clients-5.3p1-117.el6 \
+	openssh-5.3p1-118.1.el6_8 \
+	openssh-server-5.3p1-118.1.el6_8 \
+	openssh-clients-5.3p1-118.1.el6_8 \
 	python-setuptools-0.6.10-3.el6 \
 	yum-plugin-versionlock-1.1.30-37.el6 \
 	&& yum versionlock add \

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,8 @@ RUN rpm --rebuilddb \
 	python-setuptools \
 	yum-plugin-versionlock \
 	&& rm -rf /var/cache/yum/* \
+	&& rpm --erase --nodeps redhat-logos \
+	&& rpm --rebuilddb \
 	&& yum clean all
 
 # -----------------------------------------------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # =============================================================================
 # jdeathe/centos-ssh
 #
-# CentOS-6 6.7 x86_64 - SCL/EPEL/IUS Repos. / Supervisor / OpenSSH.
+# CentOS-6 6.8 x86_64 - SCL/EPEL/IUS Repos. / Supervisor / OpenSSH.
 # 
 # =============================================================================
-FROM centos:centos6.7
+FROM centos:centos6.8
 
 MAINTAINER James Deathe <james.deathe@gmail.com>
 

--- a/README-short.txt
+++ b/README-short.txt
@@ -1,1 +1,1 @@
-CentOS-6 6.7 x86_64 / CentOS-7 7.2.1511 x86_64 - SCL/EPEL/IUS Repos / Supervisor / OpenSSH.
+CentOS-6 6.8 x86_64 / CentOS-7 7.2.1511 x86_64 - SCL/EPEL/IUS Repos / Supervisor / OpenSSH.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 centos-ssh
 ==========
 
-Docker Images of CentOS-6 6.7 x86_64 / CentOS-7 7.2.1511 x86_64
+Docker Images of CentOS-6 6.8 x86_64 / CentOS-7 7.2.1511 x86_64
 
 Includes public key authentication, Automated password generation, supports custom configuration via environment variables and/or a configuration data volume.
 


### PR DESCRIPTION
Resolves #260 
- Update source to CentOS-6 6.8.
- Update OpenSSH package to 5.3p1-118.1.el6_8 from 5.3p1-117.el6.
- Remove redhat-logos to reduce image size.
