### PR TITLE
CLOSES #286: Fixed issue with purging i18n resources.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,7 +100,7 @@ RUN mkdir -p /etc/supervisord.d/ \
 # -----------------------------------------------------------------------------
 RUN rm -rf /etc/ld.so.cache \ 
 	; rm -rf /sbin/sln \
-	; rm -rf /usr/{{lib,share}/locale,share/{man,doc,info,gnome/help,cracklib,il8n},{lib,lib64}/gconv,bin/localedef,sbin/build-locale-archive} \
+	; rm -rf /usr/{{lib,share}/locale,share/{man,doc,info,cracklib,i18n},{lib,lib64}/gconv,bin/localedef,sbin/build-locale-archive} \
 	; rm -rf /{root,tmp,var/cache/{ldconfig,yum}}/* \
 	; > /etc/sysconfig/i18n
 


### PR DESCRIPTION
Resolves #286 
- Corrected typo that prevented the /usr/share/i18n directory from being deleted.
- Removed attempt to remove none existent directory /usr/share/gnome/help.
