### PR TITLE
CLOSES #259: Allow optional parameters to be appended to create/run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,7 @@ create: prerequisites require-docker-container-not
 	@ set -x; \
 		$(docker) create \
 			$(DOCKER_CONTAINER_PARAMETERS) \
+			$(DOCKER_CONTAINER_PARAMETERS_APPEND) \
 			$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) 1> /dev/null;
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=created") ]]; then \
 			echo "$(PREFIX_SUB_STEP) $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=created")"; \
@@ -306,6 +307,7 @@ run: prerequisites require-docker-image-tag
 		$(docker) run \
 			--detach \
 			$(DOCKER_CONTAINER_PARAMETERS) \
+			$(DOCKER_CONTAINER_PARAMETERS_APPEND) \
 			$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) 1> /dev/null;
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
 			echo "$(PREFIX_SUB_STEP) $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running")"; \

--- a/environment.mk
+++ b/environment.mk
@@ -17,21 +17,6 @@ NO_CACHE ?= false
 # Directory path for release packages
 PACKAGE_PATH ?= ./packages/jdeathe
 
-# VOLUME_CONFIG_NAME := volume-config.${SERVICE_UNIT_NAME}
-# VOLUME_CONFIG_NAME := volume-config.${SERVICE_UNIT_NAME}.${SERVICE_UNIT_SHARED_GROUP}
-VOLUME_CONFIG_NAME := volume-config.ssh.pool-1.1.1
-
-# Use of a configuration volume requires additional maintenance and access to the
-# filesystem of the docker host so is disabled by default.
-VOLUME_CONFIG_ENABLED := false
-
-# Using named volumes allows for easier identification of files located in
-# /var/lib/docker/volumes/ on the docker host. If set to true, the value of
-# VOLUME_CONFIG_NAME is used in place of an automatically generated ID.
-# NOTE: When using named volumes you need to copy the contents of the directory
-# into the configuration "data" volume container.
-VOLUME_CONFIG_NAMED := false
-
 # Application container configuration
 SSH_AUTHORIZED_KEYS ?=
 SSH_AUTOSTART_SSHD ?= true

--- a/environment.mk
+++ b/environment.mk
@@ -1,15 +1,23 @@
+# -----------------------------------------------------------------------------
+# Constants
+# -----------------------------------------------------------------------------
+DOCKER_USER := jdeathe
+DOCKER_IMAGE_NAME := centos-ssh
 
 # Tag validation patterns
 DOCKER_IMAGE_TAG_PATTERN := ^(latest|(centos-[6-7])|(centos-(6-1|7-2).[0-9]+.[0-9]+))$
 DOCKER_IMAGE_RELEASE_TAG_PATTERN := ^centos-(6-1|7-2).[0-9]+.[0-9]+$
 
+# -----------------------------------------------------------------------------
+# Variables
+# -----------------------------------------------------------------------------
+
 # Docker image/container settings
-DOCKER_USER := jdeathe
-DOCKER_IMAGE_NAME := centos-ssh
+DOCKER_CONTAINER_PARAMETERS_APPEND ?=
 DOCKER_IMAGE_TAG ?= latest
 DOCKER_NAME ?= ssh.pool-1.1.1
 DOCKER_PORT_MAP_TCP_22 ?= 2020
-DOCKER_RESTART_POLICY ?= always # {no,on-failure[:max-retries],always,unless-stopped}
+DOCKER_RESTART_POLICY ?= always
 
 # Docker build --no-cache parameter
 NO_CACHE ?= false

--- a/ssh.pool-1@.service
+++ b/ssh.pool-1@.service
@@ -48,6 +48,7 @@ After=docker.service
 Restart=on-failure
 RestartSec=30
 TimeoutStartSec=1200
+Environment="DOCKER_CONTAINER_PARAMETERS_APPEND="
 Environment="DOCKER_IMAGE_PACKAGE_PATH=/var/services-packages"
 Environment="DOCKER_IMAGE_NAME=jdeathe/centos-ssh"
 Environment="DOCKER_IMAGE_TAG=centos-7-2.0.3"
@@ -117,6 +118,7 @@ ExecStart=/bin/bash -c \
       --env \"SSH_USER_PASSWORD_HASHED=${SSH_USER_PASSWORD_HASHED}\" \
       --env \"SSH_USER_SHELL=${SSH_USER_SHELL}\" \
       --env \"SSH_USER_ID=${SSH_USER_ID}\" \
+      \"${DOCKER_CONTAINER_PARAMETERS_APPEND}\" \
       ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}; \
   "
 


### PR DESCRIPTION
Resolves #259 

Using `DOCKER_CONTAINER_PARAMETERS_APPEND` the operator can append additional create/run parameters such as `--volume {volume_name}:{container_path}` or `label org.deathe.license="MIT"` etc.
