### PR TITLE
CLOSES #332: Removes default requiretty from sudoers configuration.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,10 @@ RUN sed -i \
 # -----------------------------------------------------------------------------
 # Enable the wheel sudoers group
 # -----------------------------------------------------------------------------
-RUN sed -i 's~^# %wheel\tALL=(ALL)\tALL~%wheel\tALL=(ALL) ALL~g' /etc/sudoers
+RUN sed -i \
+	-e 's~^# %wheel\tALL=(ALL)\tALL~%wheel\tALL=(ALL) ALL~g' \
+	-e 's~\(.*\) requiretty$~#\1requiretty~' \
+	/etc/sudoers
 
 # -----------------------------------------------------------------------------
 # Copy files into place


### PR DESCRIPTION
Resolves #332 
- Removes `Default requiretty` from sudoers configuration. This allows for sudo commands to be run via without the requirement to use the `-t` option of the `ssh` command.
