### PR TITLE
CLOSES #340: Fixes issues using scmi for atomic install/unistall

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,36 +11,39 @@ MAINTAINER James Deathe <james.deathe@gmail.com>
 # -----------------------------------------------------------------------------
 # Import the RPM GPG keys for Repositories
 # -----------------------------------------------------------------------------
-RUN rpm --import http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-7 \
-	&& rpm --import https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7 \
-	&& rpm --import https://dl.iuscommunity.org/pub/ius/IUS-COMMUNITY-GPG-KEY
+RUN rpm --import \
+		http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-7 \
+	&& rpm --import \
+		https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7 \
+	&& rpm --import \
+		https://dl.iuscommunity.org/pub/ius/IUS-COMMUNITY-GPG-KEY
 
 # -----------------------------------------------------------------------------
 # Base Install
 # -----------------------------------------------------------------------------
 RUN rpm --rebuilddb \
 	&& yum -y install \
-	centos-release-scl \
-	centos-release-scl-rh \
-	epel-release \
-	https://centos7.iuscommunity.org/ius-release.rpm \
-	vim-minimal-7.4.160-1.el7 \
-	xz-5.1.2-12alpha.el7.x86_64 \
-	sudo-1.8.6p7-17.el7_2 \
-	openssh-6.6.1p1-25.el7_2 \
-	openssh-server-6.6.1p1-25.el7_2 \
-	openssh-clients-6.6.1p1-25.el7_2 \
-	python-setuptools-0.9.8-4.el7 \
-	yum-plugin-versionlock-1.1.31-34.el7 \
+		centos-release-scl \
+		centos-release-scl-rh \
+		epel-release \
+		https://centos7.iuscommunity.org/ius-release.rpm \
+		vim-minimal-7.4.160-1.el7 \
+		xz-5.1.2-12alpha.el7.x86_64 \
+		sudo-1.8.6p7-17.el7_2 \
+		openssh-6.6.1p1-25.el7_2 \
+		openssh-server-6.6.1p1-25.el7_2 \
+		openssh-clients-6.6.1p1-25.el7_2 \
+		python-setuptools-0.9.8-4.el7 \
+		yum-plugin-versionlock-1.1.31-34.el7 \
 	&& yum versionlock add \
-	vim-minimal \
-	xz \
-	sudo \
-	openssh \
-	openssh-server \
-	openssh-clients \
-	python-setuptools \
-	yum-plugin-versionlock \
+		vim-minimal \
+		xz \
+		sudo \
+		openssh \
+		openssh-server \
+		openssh-clients \
+		python-setuptools \
+		yum-plugin-versionlock \
 	&& rm -rf /var/cache/yum/* \
 	&& yum clean all
 
@@ -50,13 +53,18 @@ RUN rpm --rebuilddb \
 # We require supervisor-stdout to allow output of services started by 
 # supervisord to be easily inspected with "docker logs".
 # -----------------------------------------------------------------------------
-RUN easy_install 'supervisor == 3.3.1' 'supervisor-stdout == 0.1.1' \
-	&& mkdir -p /var/log/supervisor/
+RUN easy_install \
+		'supervisor == 3.3.1' \
+		'supervisor-stdout == 0.1.1' \
+	&& mkdir -p \
+		/var/log/supervisor/
 
 # -----------------------------------------------------------------------------
 # UTC Timezone & Networking
 # -----------------------------------------------------------------------------
-RUN ln -sf /usr/share/zoneinfo/UTC /etc/localtime \
+RUN ln -sf \
+		/usr/share/zoneinfo/UTC \
+		/etc/localtime \
 	&& echo "NETWORKING=yes" > /etc/sysconfig/network
 
 # -----------------------------------------------------------------------------
@@ -96,15 +104,31 @@ ADD etc/services-config/supervisor/supervisord.d/sshd.conf \
 	etc/services-config/supervisor/supervisord.d/sshd-bootstrap.conf \
 	/etc/services-config/supervisor/supervisord.d/
 
-RUN mkdir -p /etc/supervisord.d/ \
-	&& cp -pf /etc/ssh/sshd_config /etc/services-config/ssh/ \
-	&& ln -sf /etc/services-config/ssh/sshd_config /etc/ssh/sshd_config \
-	&& ln -sf /etc/services-config/ssh/sshd-bootstrap.conf /etc/sshd-bootstrap.conf \
-	&& ln -sf /etc/services-config/ssh/sshd-bootstrap.env /etc/sshd-bootstrap.env \
-	&& ln -sf /etc/services-config/supervisor/supervisord.conf /etc/supervisord.conf \
-	&& ln -sf /etc/services-config/supervisor/supervisord.d/sshd.conf /etc/supervisord.d/sshd.conf \
-	&& ln -sf /etc/services-config/supervisor/supervisord.d/sshd-bootstrap.conf /etc/supervisord.d/sshd-bootstrap.conf \
-	&& chmod +x /usr/sbin/{scmi,sshd-bootstrap}
+RUN mkdir -p \
+		/etc/supervisord.d/ \
+	&& cp -pf \
+		/etc/ssh/sshd_config \
+		/etc/services-config/ssh/ \
+	&& ln -sf \
+		/etc/services-config/ssh/sshd_config \
+		/etc/ssh/sshd_config \
+	&& ln -sf \
+		/etc/services-config/ssh/sshd-bootstrap.conf \
+		/etc/sshd-bootstrap.conf \
+	&& ln -sf \
+		/etc/services-config/ssh/sshd-bootstrap.env \
+		/etc/sshd-bootstrap.env \
+	&& ln -sf \
+		/etc/services-config/supervisor/supervisord.conf \
+		/etc/supervisord.conf \
+	&& ln -sf \
+		/etc/services-config/supervisor/supervisord.d/sshd.conf \
+		/etc/supervisord.d/sshd.conf \
+	&& ln -sf \
+		/etc/services-config/supervisor/supervisord.d/sshd-bootstrap.conf \
+		/etc/supervisord.d/sshd-bootstrap.conf \
+	&& chmod 700 \
+		/usr/sbin/{scmi,sshd-bootstrap}
 
 # -----------------------------------------------------------------------------
 # Purge

--- a/Dockerfile
+++ b/Dockerfile
@@ -144,7 +144,7 @@ LABEL \
 --privileged \
 --volume /:/media/root \
 jdeathe/centos-ssh:centos-7-${RELEASE_VERSION} \
-/sbin/scmi install \
+/usr/sbin/scmi install \
 --chroot=/media/root \
 --name=\${NAME} \
 --tag=centos-7-${RELEASE_VERSION} \
@@ -154,7 +154,7 @@ jdeathe/centos-ssh:centos-7-${RELEASE_VERSION} \
 --privileged \
 --volume /:/media/root \
 jdeathe/centos-ssh:centos-7-${RELEASE_VERSION} \
-/sbin/scmi uninstall \
+/usr/sbin/scmi uninstall \
 --chroot=/media/root \
 --name=\${NAME} \
 --tag=centos-7-${RELEASE_VERSION} \

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,7 @@ create: prerequisites require-docker-container-not
 	@ set -x; \
 		$(docker) create \
 			$(DOCKER_CONTAINER_PARAMETERS) \
+			$(DOCKER_PUBLISH) \
 			$(DOCKER_CONTAINER_PARAMETERS_APPEND) \
 			$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) 1> /dev/null;
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=created") ]]; then \
@@ -323,6 +324,7 @@ run: prerequisites require-docker-image-tag
 		$(docker) run \
 			--detach \
 			$(DOCKER_CONTAINER_PARAMETERS) \
+			$(DOCKER_PUBLISH) \
 			$(DOCKER_CONTAINER_PARAMETERS_APPEND) \
 			$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) 1> /dev/null;
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \

--- a/default.mk
+++ b/default.mk
@@ -2,7 +2,6 @@
 # Common parameters of create and run targets
 define DOCKER_CONTAINER_PARAMETERS
 --name $(DOCKER_NAME) \
---publish $(DOCKER_PORT_MAP_TCP_22):22 \
 --restart $(DOCKER_RESTART_POLICY) \
 --env "SSH_AUTHORIZED_KEYS=$(SSH_AUTHORIZED_KEYS)" \
 --env "SSH_AUTOSTART_SSHD=$(SSH_AUTOSTART_SSHD)" \
@@ -18,3 +17,7 @@ define DOCKER_CONTAINER_PARAMETERS
 --env "SSH_USER_PASSWORD_HASHED=$(SSH_USER_PASSWORD_HASHED)" \
 --env "SSH_USER_SHELL=$(SSH_USER_SHELL)"
 endef
+
+DOCKER_PUBLISH := $(shell \
+	if [[ $(DOCKER_PORT_MAP_TCP_22) != NULL ]]; then printf -- '--publish %s:22\n' $(DOCKER_PORT_MAP_TCP_22); fi; \
+)

--- a/environment.mk
+++ b/environment.mk
@@ -25,7 +25,9 @@ NO_CACHE ?= false
 # Directory path for release packages
 PACKAGE_PATH ?= ./packages/jdeathe
 
+# ------------------------------------------------------------------------------
 # Application container configuration
+# ------------------------------------------------------------------------------
 SSH_AUTHORIZED_KEYS ?=
 SSH_AUTOSTART_SSHD ?= true
 SSH_AUTOSTART_SSHD_BOOTSTRAP ?= true

--- a/etc/systemd/system/centos-ssh.register@.service
+++ b/etc/systemd/system/centos-ssh.register@.service
@@ -65,13 +65,15 @@ ExecStartPre=/bin/bash -c \
 
 # Register service
 ExecStart=/bin/bash -c \
-  "while ! /usr/bin/etcdctl ${REGISTER_ETCD_PARAMETERS} get ${REGISTER_KEY_ROOT}/ports/tcp/22 &> /dev/null; do \
-    /usr/bin/etcdctl \
-      ${REGISTER_ETCD_PARAMETERS} \
-      mk \
-      ${REGISTER_KEY_ROOT}/ports/tcp/22 \
-      $(/usr/bin/sed 's/^[0-9.]*://' <<< $(if ! /usr/bin/docker port {{SERVICE_UNIT_NAME}}.%i 22 &> /dev/null; then echo ''; else /usr/bin/docker port {{SERVICE_UNIT_NAME}}.%i 22; fi)) \
-      --ttl ${REGISTER_TTL} 2> /dev/null; \
+  "until /usr/bin/etcdctl ${REGISTER_ETCD_PARAMETERS} get ${REGISTER_KEY_ROOT}/ports/tcp/22 &> /dev/null; do \
+    if /usr/bin/docker port {{SERVICE_UNIT_NAME}}.%i 22 &> /dev/null; then \
+      /usr/bin/etcdctl \
+        ${REGISTER_ETCD_PARAMETERS} \
+        mk \
+        ${REGISTER_KEY_ROOT}/ports/tcp/22 \
+        \"$(/usr/bin/docker port {{SERVICE_UNIT_NAME}}.%i 22 | /usr/bin/sed 's~^[0-9.]*:~~')\" \
+        --ttl ${REGISTER_TTL} 2> /dev/null; \
+    fi; \
     sleep 0.5; \
   done; \
   /usr/bin/etcdctl \
@@ -82,12 +84,14 @@ ExecStart=/bin/bash -c \
     --ttl ${REGISTER_TTL}; \
   while true; do \
     sleep ${REGISTER_UPDATE_INTERVAL}; \
-    /usr/bin/etcdctl \
-      ${REGISTER_ETCD_PARAMETERS} \
-      $(if ! /usr/bin/etcdctl ${REGISTER_ETCD_PARAMETERS} get ${REGISTER_KEY_ROOT}/ports/tcp/22 &> /dev/null; then echo set; else echo update; fi) \
-      ${REGISTER_KEY_ROOT}/ports/tcp/22 \
-      $(/usr/bin/sed 's/^[0-9.]*://' <<< $(if ! /usr/bin/docker port {{SERVICE_UNIT_NAME}}.%i 22 &> /dev/null; then echo ''; else /usr/bin/docker port {{SERVICE_UNIT_NAME}}.%i 22; fi)) \
-      --ttl ${REGISTER_TTL}; \
+    if /usr/bin/docker port {{SERVICE_UNIT_NAME}}.%i 22 &> /dev/null; then \
+      /usr/bin/etcdctl \
+        ${REGISTER_ETCD_PARAMETERS} \
+        $(if ! /usr/bin/etcdctl ${REGISTER_ETCD_PARAMETERS} get ${REGISTER_KEY_ROOT}/ports/tcp/22 &> /dev/null; then echo set; else echo update; fi) \
+        ${REGISTER_KEY_ROOT}/ports/tcp/22 \
+        \"$(/usr/bin/docker port {{SERVICE_UNIT_NAME}}.%i 22 | /usr/bin/sed 's~^[0-9.]*:~~')\" \
+        --ttl ${REGISTER_TTL}; \
+    fi; \
     /usr/bin/etcdctl \
       ${REGISTER_ETCD_PARAMETERS} \
       $(if ! /usr/bin/etcdctl ${REGISTER_ETCD_PARAMETERS} get ${REGISTER_KEY_ROOT}/hostname &> /dev/null; then echo set; else echo update; fi) \

--- a/etc/systemd/system/centos-ssh@.service
+++ b/etc/systemd/system/centos-ssh@.service
@@ -110,15 +110,15 @@ ExecStart=/bin/bash -c \
     --env \"SSH_USER_SHELL=${SSH_USER_SHELL}\" \
     $(\
       if [[ ${DOCKER_PORT_MAP_TCP_22} != NULL ]]; then \
-	      if [[ -n $(/usr/bin/gawk 'match($0, /^([0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}:)?([0-9]+)$/, matches) { print matches[2]; }' <<< \"${DOCKER_PORT_MAP_TCP_22}\") ]]; then \
-	        printf -- '--publish %%s%%s:22' \
-	          \"$(/usr/bin/gawk 'match($0, /^([0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}:)?([0-9]+)$/, matches) { print matches[1]; }' <<< \"${DOCKER_PORT_MAP_TCP_22}\")\" \
-	          \"$(( $(/usr/bin/gawk 'match($0, /^([0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}:)?([0-9]+)$/, matches) { print matches[2]; }' <<< \"${DOCKER_PORT_MAP_TCP_22}\") + $(/usr/bin/awk -F. '$0=$1' <<< %i) - 1 ))\"; \
-	      else \
-	        printf -- '--publish %%s:22' \
-	          \"${DOCKER_PORT_MAP_TCP_22}\"; \
-	      fi; \
-			fi; \
+        if [[ -n $(/usr/bin/gawk 'match($0, /^([0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}:)?([0-9]+)$/, matches) { print matches[2]; }' <<< \"${DOCKER_PORT_MAP_TCP_22}\") ]]; then \
+          printf -- '--publish %%s%%s:22' \
+            \"$(/usr/bin/gawk 'match($0, /^([0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}:)?([0-9]+)$/, matches) { print matches[1]; }' <<< \"${DOCKER_PORT_MAP_TCP_22}\")\" \
+            \"$(( $(/usr/bin/gawk 'match($0, /^([0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}:)?([0-9]+)$/, matches) { print matches[2]; }' <<< \"${DOCKER_PORT_MAP_TCP_22}\") + $(/usr/bin/awk -F. '$0=$1' <<< %i) - 1 ))\"; \
+        else \
+          printf -- '--publish %%s:22' \
+            \"${DOCKER_PORT_MAP_TCP_22}\"; \
+        fi; \
+      fi; \
     ) \
     ${DOCKER_CONTAINER_PARAMETERS_APPEND} \
     ${DOCKER_USER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}; \

--- a/etc/systemd/system/centos-ssh@.service
+++ b/etc/systemd/system/centos-ssh@.service
@@ -95,16 +95,6 @@ ExecStartPre=-/bin/bash -c \
 ExecStart=/bin/bash -c \
   "exec /usr/bin/docker run \
     --name %p.%i \
-    --publish $(\
-      if [[ -n $(/usr/bin/gawk 'match($0, /^([0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}:)?([0-9]+)$/, matches) { print matches[2]; }' <<< \"${DOCKER_PORT_MAP_TCP_22}\") ]]; then \
-        printf -- '%%s%%s' \
-          \"$(/usr/bin/gawk 'match($0, /^([0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}:)?([0-9]+)$/, matches) { print matches[1]; }' <<< \"${DOCKER_PORT_MAP_TCP_22}\")\" \
-          \"$(( $(/usr/bin/gawk 'match($0, /^([0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}:)?([0-9]+)$/, matches) { print matches[2]; }' <<< \"${DOCKER_PORT_MAP_TCP_22}\") + $(/usr/bin/awk -F. '$0=$1' <<< %i) - 1 ))\"; \
-      else \
-        printf -- '%%s' \
-          \"${DOCKER_PORT_MAP_TCP_22}\"; \
-      fi; \
-    ):22 \
     --env \"SSH_AUTHORIZED_KEYS=${SSH_AUTHORIZED_KEYS}\" \
     --env \"SSH_AUTOSTART_SSHD=${SSH_AUTOSTART_SSHD}\" \
     --env \"SSH_AUTOSTART_SSHD_BOOTSTRAP=${SSH_AUTOSTART_SSHD_BOOTSTRAP}\" \
@@ -118,6 +108,18 @@ ExecStart=/bin/bash -c \
     --env \"SSH_USER_PASSWORD=${SSH_USER_PASSWORD}\" \
     --env \"SSH_USER_PASSWORD_HASHED=${SSH_USER_PASSWORD_HASHED}\" \
     --env \"SSH_USER_SHELL=${SSH_USER_SHELL}\" \
+    $(\
+      if [[ ${DOCKER_PORT_MAP_TCP_22} != NULL ]]; then \
+	      if [[ -n $(/usr/bin/gawk 'match($0, /^([0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}:)?([0-9]+)$/, matches) { print matches[2]; }' <<< \"${DOCKER_PORT_MAP_TCP_22}\") ]]; then \
+	        printf -- '--publish %%s%%s:22' \
+	          \"$(/usr/bin/gawk 'match($0, /^([0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}:)?([0-9]+)$/, matches) { print matches[1]; }' <<< \"${DOCKER_PORT_MAP_TCP_22}\")\" \
+	          \"$(( $(/usr/bin/gawk 'match($0, /^([0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}:)?([0-9]+)$/, matches) { print matches[2]; }' <<< \"${DOCKER_PORT_MAP_TCP_22}\") + $(/usr/bin/awk -F. '$0=$1' <<< %i) - 1 ))\"; \
+	      else \
+	        printf -- '--publish %%s:22' \
+	          \"${DOCKER_PORT_MAP_TCP_22}\"; \
+	      fi; \
+			fi; \
+    ) \
     ${DOCKER_CONTAINER_PARAMETERS_APPEND} \
     ${DOCKER_USER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}; \
   "


### PR DESCRIPTION
Resolves #340 
- Adds correct path to scmi on image for install/uninstall.
- Improves readability of Dockerfile.
- Adds consistent method of handling publishing of exposed ports. It's now possible to prevent publishing of the default exposed port when using scmi/make for installation.
- Adds minor improvement to the systemd register template unit-file.
