### PR TITLE
CLOSES #371: Changes PACKAGE_PATH to DIST_PATH for consistency.

### DIFF
--- a/opt/scmi/environment.sh
+++ b/opt/scmi/environment.sh
@@ -23,7 +23,7 @@ DOCKER_RESTART_POLICY="${DOCKER_RESTART_POLICY:-always}"
 NO_CACHE="${NO_CACHE:-false}"
 
 # Directory path for release packages
-PACKAGE_PATH="${PACKAGE_PATH:-./packages/jdeathe}"
+DIST_PATH="${DIST_PATH:-./dist}"
 
 # ETCD register service settings
 REGISTER_ETCD_PARAMETERS="${REGISTER_ETCD_PARAMETERS:-}"


### PR DESCRIPTION
Resolves #371 
- Changes `PACKAGE_PATH` to `DIST_PATH` in line with the Makefile environment include. Not currently used by `scmi` but changing for consistency.
