### PR TITLE
CLOSES #370: Renamed DOCKER_CONTAINER_PARAMETERS_APPEND

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,7 @@ Targets:
   unpause                   Unpause the container when in a paused state.
 
 Variables:
-  - DOCKER_CONTAINER_PARAMETERS_APPEND
-                            Set optional docker parameters to append that will 
+  - DOCKER_CONTAINER_OPTS   Set optional docker parameters to append that will 
                             be appended to the create and run templates.
   - DOCKER_IMAGE_TAG        Defines the image tag name.
   - DOCKER_NAME             Container name. The required format is as follows
@@ -276,7 +275,7 @@ create: _prerequisites _require-docker-container-not
 		$(docker) create \
 			$(DOCKER_CONTAINER_PARAMETERS) \
 			$(DOCKER_PUBLISH) \
-			$(DOCKER_CONTAINER_PARAMETERS_APPEND) \
+			$(DOCKER_CONTAINER_OPTS) \
 			$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) 1> /dev/null;
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=created") ]]; then \
 			echo "$(PREFIX_SUB_STEP) $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=created")"; \
@@ -427,7 +426,7 @@ run: _prerequisites _require-docker-image-tag
 			--detach \
 			$(DOCKER_CONTAINER_PARAMETERS) \
 			$(DOCKER_PUBLISH) \
-			$(DOCKER_CONTAINER_PARAMETERS_APPEND) \
+			$(DOCKER_CONTAINER_OPTS) \
 			$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) 1> /dev/null;
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
 			echo "$(PREFIX_SUB_STEP) $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running")"; \

--- a/environment.mk
+++ b/environment.mk
@@ -13,7 +13,7 @@ DOCKER_IMAGE_RELEASE_TAG_PATTERN := ^centos-(6-1|7-2).[0-9]+.[0-9]+$
 # -----------------------------------------------------------------------------
 
 # Docker image/container settings
-DOCKER_CONTAINER_PARAMETERS_APPEND ?=
+DOCKER_CONTAINER_OPTS ?=
 DOCKER_IMAGE_TAG ?= latest
 DOCKER_NAME ?= ssh.pool-1.1.1
 DOCKER_PORT_MAP_TCP_22 ?= 2020

--- a/etc/systemd/system/centos-ssh@.service
+++ b/etc/systemd/system/centos-ssh@.service
@@ -49,7 +49,7 @@ RestartSec=30
 TimeoutStartSec=1200
 Environment="DOCKER_USER=jdeathe"
 Environment="DOCKER_IMAGE_NAME=centos-ssh"
-Environment="DOCKER_CONTAINER_PARAMETERS_APPEND="
+Environment="DOCKER_CONTAINER_OPTS="
 Environment="DOCKER_IMAGE_PACKAGE_PATH=/var/opt/scmi/packages"
 Environment="DOCKER_IMAGE_TAG=centos-7-2.1.2"
 Environment="DOCKER_PORT_MAP_TCP_22=2020"
@@ -120,7 +120,7 @@ ExecStart=/bin/bash -c \
         fi; \
       fi; \
     ) \
-    ${DOCKER_CONTAINER_PARAMETERS_APPEND} \
+    ${DOCKER_CONTAINER_OPTS} \
     ${DOCKER_USER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}; \
   "
 

--- a/opt/scmi/environment.sh
+++ b/opt/scmi/environment.sh
@@ -13,7 +13,7 @@ DOCKER_IMAGE_RELEASE_TAG_PATTERN='^centos-(6-1|7-2).[0-9]+.[0-9]+$'
 # -----------------------------------------------------------------------------
 
 # Docker image/container settings
-DOCKER_CONTAINER_PARAMETERS_APPEND="${DOCKER_CONTAINER_PARAMETERS_APPEND:-}"
+DOCKER_CONTAINER_OPTS="${DOCKER_CONTAINER_OPTS:-}"
 DOCKER_IMAGE_TAG="${DOCKER_IMAGE_TAG:-latest}"
 DOCKER_NAME="${DOCKER_NAME:-ssh.pool-1.1.1}"
 DOCKER_PORT_MAP_TCP_22="${DOCKER_PORT_MAP_TCP_22:-2020}"

--- a/opt/scmi/service-unit.sh
+++ b/opt/scmi/service-unit.sh
@@ -2,7 +2,7 @@
 # Constants
 # -----------------------------------------------------------------------------
 SERVICE_UNIT_ENVIRONMENT_KEYS="
- DOCKER_CONTAINER_PARAMETERS_APPEND
+ DOCKER_CONTAINER_OPTS
  DOCKER_IMAGE_PACKAGE_PATH
  DOCKER_IMAGE_TAG
  DOCKER_PORT_MAP_TCP_22

--- a/usr/sbin/scmi
+++ b/usr/sbin/scmi
@@ -257,9 +257,9 @@ function scmi ()
 			fi
 
 			printf -v \
-				DOCKER_CONTAINER_PARAMETERS_APPEND \
+				DOCKER_CONTAINER_OPTS \
 				-- '%s %s' \
-				"${DOCKER_CONTAINER_PARAMETERS_APPEND}" \
+				"${DOCKER_CONTAINER_OPTS}" \
 				"$(
 					sed \
 						-e "s~{{NAME}}~${DOCKER_NAME}~g" \
@@ -372,7 +372,7 @@ function scmi_docker_get_create_template ()
 		'%s create %s %s %s/%s:%s' \
 		"${docker}" \
 		"${DOCKER_CONTAINER_PARAMETERS}" \
-		"${DOCKER_CONTAINER_PARAMETERS_APPEND}" \
+		"${DOCKER_CONTAINER_OPTS}" \
 		"${DOCKER_USER}" \
 		"${DOCKER_IMAGE_NAME}" \
 		"${DOCKER_IMAGE_TAG}"


### PR DESCRIPTION
Resolves #370 
- Renamed `DOCKER_CONTAINER_PARAMETERS_APPEND` to `DOCKER_CONTAINER_OPTS` for usability. This is a potentially breaking change that could affect systemd service configurations if using the Environment variable in a drop-in customisation. However, if using the systemd template unit-files it should be pinned to a specific version tag. The Makefile should only be used for development/testing and usage in `scmi` is internal only as the `--setopt` parameter is used to build up the optional container parameters. 
