### PR TITLE
CLOSES #398: Removes requirement for gawk in port handling.

### DIFF
--- a/etc/systemd/system/centos-ssh@.service
+++ b/etc/systemd/system/centos-ssh@.service
@@ -108,18 +108,16 @@ ExecStart=/bin/bash -c \
     --env \"SSH_USER_PASSWORD=${SSH_USER_PASSWORD}\" \
     --env \"SSH_USER_PASSWORD_HASHED=${SSH_USER_PASSWORD_HASHED}\" \
     --env \"SSH_USER_SHELL=${SSH_USER_SHELL}\" \
-    $(\
-      if [[ ${DOCKER_PORT_MAP_TCP_22} != NULL ]]; then \
-        if [[ -n $(/usr/bin/gawk 'match($0, /^([0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}:)?([0-9]+)$/, matches) { print matches[2]; }' <<< \"${DOCKER_PORT_MAP_TCP_22}\") ]]; then \
-          printf -- '--publish %%s%%s:22' \
-            \"$(/usr/bin/gawk 'match($0, /^([0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}:)?([0-9]+)$/, matches) { print matches[1]; }' <<< \"${DOCKER_PORT_MAP_TCP_22}\")\" \
-            \"$(( $(/usr/bin/gawk 'match($0, /^([0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}:)?([0-9]+)$/, matches) { print matches[2]; }' <<< \"${DOCKER_PORT_MAP_TCP_22}\") + $(/usr/bin/awk -F. '$0=$1' <<< %i) - 1 ))\"; \
-        else \
-          printf -- '--publish %%s:22' \
-            \"${DOCKER_PORT_MAP_TCP_22}\"; \
-        fi; \
+    $(if [[ ${DOCKER_PORT_MAP_TCP_22} != NULL ]]; then \
+      if /usr/bin/grep -qE '^([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}:)?[0-9]*$' <<< \"${DOCKER_PORT_MAP_TCP_22}\"; then \
+        printf -- '--publish %%s%%s:22' \
+          $(/usr/bin/grep -o '^[0-9\.]*:' <<< \"${DOCKER_PORT_MAP_TCP_22}\") \
+          $(( $(/usr/bin/grep -o '[0-9]*$' <<< \"${DOCKER_PORT_MAP_TCP_22}\") + $(/usr/bin/sed 's~\.[0-9]*$~~' <<< %i) - 1 )); \
+      else \
+        printf -- '--publish %%s:22' \
+          \"${DOCKER_PORT_MAP_TCP_22}\"; \
       fi; \
-    ) \
+    fi) \
     ${DOCKER_CONTAINER_OPTS} \
     ${DOCKER_USER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}; \
   "


### PR DESCRIPTION
Resolves #398 

- Removes requirement for `gawk` in the port handling functions for SCMI and the systemd template unit-file.