### PR TITLE
CLOSES #411: Adds -u parameter to sshd options to help reduce DNS lookups.

### DIFF
--- a/usr/sbin/sshd-wrapper
+++ b/usr/sbin/sshd-wrapper
@@ -6,6 +6,7 @@ SSHD=/usr/sbin/sshd
 SSHD_OPTIONS="
  -D
  -e
+ -u 0
 "
 
 while true; do


### PR DESCRIPTION
Resolves #411 - Patch back #399.

- Adds `-u` parameter to `sshd` options to help reduce time spent doing DNS lookups.