### PR TITLE
CLOSES #434: Adds support to run tests on Ubuntu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -504,7 +504,7 @@ test: _test-prerequisites
 			$(MAKE) build; \
 		fi;
 	@ echo "$(PREFIX_STEP) Functional test";
-	@ env SHPEC_ROOT=$(SHPEC_ROOT) $(shpec);
+	@ SHPEC_ROOT=$(SHPEC_ROOT) $(shpec);
 
 unpause: _prerequisites _require-docker-container-status-paused
 	@ echo "$(PREFIX_STEP) Unpausing container"

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -932,8 +932,8 @@ describe "jdeathe/centos-ssh:latest"
 			sleep ${BOOTSTRAP_BACKOFF_TIME}
 
 			docker cp \
-				test/fixture/test_directory/var/www \
-				www-data.pool-1.1.1:/var/
+				test/fixture/test_directory/var/www/. \
+				www-data.pool-1.1.1:/var/www
 			docker exec www-data.pool-1.1.1 \
 				chown -R app-admin:app-admin /var/www/test
 


### PR DESCRIPTION
Resolves #434 

- Adds support to run tests on Ubuntu

Needs some additional setup prevent warnings about locale.

```
sudo locale-gen en_US.UTF-8; sudo dpkg-reconfigure locales
export LANG=en_US.UTF-8; unset LANGUAGE LC_ALL LC_CTYPE
```