### PR TITLE
CLOSES #452: Adds correct version of CentOS-7 to README.

### DIFF
--- a/README-short.txt
+++ b/README-short.txt
@@ -1,1 +1,1 @@
-CentOS-6 6.8 x86_64 / CentOS-7 7.2.1511 x86_64 - SCL/EPEL/IUS Repos / Supervisor / OpenSSH.
+CentOS-6 6.8 x86_64 / CentOS-7 7.3.1611 x86_64 - SCL/EPEL/IUS Repos / Supervisor / OpenSSH.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 centos-ssh
 ==========
 
-Docker Images of CentOS-6 6.8 x86_64 / CentOS-7 7.2.1511 x86_64
+Docker Images of CentOS-6 6.8 x86_64 / CentOS-7 7.3.1611 x86_64
 
 Includes public key authentication, Automated password generation and supports custom configuration via environment variables.
 


### PR DESCRIPTION
Resolves #452 

- Adds correct version of CentOS-7 to `README.md` since updating to `7.3.1611` #450.