### PR TITLE
CLOSES #456: Updates packages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Summary of release changes for Version 2 - CentOS-7
 ### 2.2.1 - Unreleased
 
 - Updates `vim` and `openssh` packages and the `epel-release`.
+- Fixes `shpec` test definition to allow `make test` to be interruptible.
 
 ### 2.2.0 - 2016-12-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Summary of release changes for Version 2 - CentOS-7
 
+### 2.2.1 - Unreleased
+
+- Updates `vim` and `openssh` packages and the `epel-release`.
+
 ### 2.2.0 - 2016-12-19
 
 - Adds CentOS 7.3.1611 source tag.

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,12 +23,12 @@ RUN rpm --rebuilddb \
 		centos-release-scl-rh \
 		epel-release \
 		https://centos7.iuscommunity.org/ius-release.rpm \
-		vim-minimal-7.4.160-1.el7 \
+		vim-minimal-7.4.160-1.el7_3.1 \
 		xz-5.2.2-1.el7 \
 		sudo-1.8.6p7-21.el7_3 \
-		openssh-6.6.1p1-31.el7 \
-		openssh-server-6.6.1p1-31.el7 \
-		openssh-clients-6.6.1p1-31.el7 \
+		openssh-6.6.1p1-33.el7_3 \
+		openssh-server-6.6.1p1-33.el7_3 \
+		openssh-clients-6.6.1p1-33.el7_3 \
 		python-setuptools-0.9.8-4.el7 \
 		yum-plugin-versionlock-1.1.31-40.el7 \
 	&& yum versionlock add \

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -50,7 +50,7 @@ describe "jdeathe/centos-ssh:latest"
 	test_setup
 
 	describe "Basic SSH operations"
-		trap "docker_terminate_container ssh.pool-1.1.1 &> /dev/null" \
+		trap "docker_terminate_container ssh.pool-1.1.1 &> /dev/null; exit 1" \
 			INT TERM EXIT
 
 		docker_terminate_container ssh.pool-1.1.1 &> /dev/null
@@ -147,7 +147,7 @@ describe "jdeathe/centos-ssh:latest"
 	end
 	
 	describe "Basic SFTP operations"
-		trap "docker_terminate_container sftp.pool-1.1.1 &> /dev/null" \
+		trap "docker_terminate_container sftp.pool-1.1.1 &> /dev/null; exit 1" \
 			INT TERM EXIT
 
 		docker_terminate_container sftp.pool-1.1.1 &> /dev/null
@@ -238,7 +238,7 @@ describe "jdeathe/centos-ssh:latest"
 	end
 
 	describe "Customised SSH configuration"
-		trap "docker_terminate_container ssh.pool-1.1.1 &> /dev/null" \
+		trap "docker_terminate_container ssh.pool-1.1.1 &> /dev/null; exit 1" \
 			INT TERM EXIT
 
 		it "Allows configuration of passwordless sudo."
@@ -819,7 +819,7 @@ describe "jdeathe/centos-ssh:latest"
 	end
 
 	describe "Customised SFTP configuration"
-		trap "docker_terminate_container sftp.pool-1.1.1 &> /dev/null; docker_terminate_container www-data.pool-1.1.1 &> /dev/null; docker volume rm www-data.pool-1.1.1 &> /dev/null" \
+		trap "docker_terminate_container sftp.pool-1.1.1 &> /dev/null; docker_terminate_container www-data.pool-1.1.1 &> /dev/null; docker volume rm www-data.pool-1.1.1 &> /dev/null; exit 1" \
 			INT TERM EXIT
 
 		docker_terminate_container sftp.pool-1.1.1 &> /dev/null


### PR DESCRIPTION
Resolves #456 

- Updates `vim` and `openssh` packages and the `epel-release`.
- Fixes `shpec` test definition to allow `make test` to be interruptible.