### PR TITLE
CLOSES #456: Updates vim package.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 Summary of release changes for Version 1 - CentOS-6
 
+### 1.7.6 - Unreleased
+
+- Adds updated CentOS-7 version in `README.md` since updating to `7.3.1611`.
+- Updates the `vim` package.
+- Fixes `shpec` test definition to allow `make test` to be interruptible.
+
 ### 1.7.5 - 2016-12-15
 
 - Adds updated `sudo` package.

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN rpm --rebuilddb \
 		centos-release-scl-rh \
 		epel-release \
 		https://centos6.iuscommunity.org/ius-release.rpm \
-		vim-minimal-7.4.629-5.el6 \
+		vim-minimal-7.4.629-5.el6_8.1 \
 		xz-4.999.9-0.5.beta.20091007git.el6.x86_64 \
 		sudo-1.8.6p3-25.el6_8 \
 		openssh-5.3p1-118.1.el6_8 \

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -50,7 +50,7 @@ describe "jdeathe/centos-ssh:latest"
 	test_setup
 
 	describe "Basic SSH operations"
-		trap "docker_terminate_container ssh.pool-1.1.1 &> /dev/null" \
+		trap "docker_terminate_container ssh.pool-1.1.1 &> /dev/null; exit 1" \
 			INT TERM EXIT
 
 		docker_terminate_container ssh.pool-1.1.1 &> /dev/null
@@ -147,7 +147,7 @@ describe "jdeathe/centos-ssh:latest"
 	end
 	
 	describe "Basic SFTP operations"
-		trap "docker_terminate_container sftp.pool-1.1.1 &> /dev/null" \
+		trap "docker_terminate_container sftp.pool-1.1.1 &> /dev/null; exit 1" \
 			INT TERM EXIT
 
 		docker_terminate_container sftp.pool-1.1.1 &> /dev/null
@@ -238,7 +238,7 @@ describe "jdeathe/centos-ssh:latest"
 	end
 
 	describe "Customised SSH configuration"
-		trap "docker_terminate_container ssh.pool-1.1.1 &> /dev/null" \
+		trap "docker_terminate_container ssh.pool-1.1.1 &> /dev/null; exit 1" \
 			INT TERM EXIT
 
 		it "Allows configuration of passwordless sudo."
@@ -819,7 +819,7 @@ describe "jdeathe/centos-ssh:latest"
 	end
 
 	describe "Customised SFTP configuration"
-		trap "docker_terminate_container sftp.pool-1.1.1 &> /dev/null; docker_terminate_container www-data.pool-1.1.1 &> /dev/null; docker volume rm www-data.pool-1.1.1 &> /dev/null" \
+		trap "docker_terminate_container sftp.pool-1.1.1 &> /dev/null; docker_terminate_container www-data.pool-1.1.1 &> /dev/null; docker volume rm www-data.pool-1.1.1 &> /dev/null; exit 1" \
 			INT TERM EXIT
 
 		docker_terminate_container sftp.pool-1.1.1 &> /dev/null


### PR DESCRIPTION
Resolves #456 

- Adds updated CentOS-7 version in `README.md` since updating to `7.3.1611`.
- Updates the `vim` package.
- Fixes `shpec` test definition to allow `make test` to be interruptible.