### PR TITLE
Remove extra quotes around SSH_SUDO in run example

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ $ docker run \
     --name=ssh.pool-1.1.1 \
     --manager=systemd \
     --register \
-    --env='SSH_SUDO="ALL=(ALL) NOPASSWD:ALL"' \
+    --env='SSH_SUDO=ALL=(ALL) NOPASSWD:ALL' \
     --env='SSH_USER="centos"' \
     --setopt='--volume {{NAME}}.config-ssh:/etc/ssh'
 ```


### PR DESCRIPTION
Quotes in the run example produce invalid sudoers configuration.

```
# Darwin
# $? 0
# ./ ~
# t  0
cid=$(docker run --env='SSH_SUDO="ALL=(ALL) NOPASSWD:ALL"' -d --rm -P jdeathe/centos-ssh:centos-7 )
# Darwin
# $? 0
# ./ ~
# t  1
docker exec -it $cid grep wheel /etc/sudoers
## Allows people in group wheel to run all commands
%wheel	"ALL=(ALL) NOPASSWD:ALL"
# %wheel	ALL=(ALL)	NOPASSWD: ALL
```