### PR TITLE
CLOSES #460: Use 'docker pull' before 'docker inspect' on an image.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Summary of release changes for Version 2 - CentOS-7
 - Updates `vim` and `openssh` packages and the `epel-release`.
 - Fixes `shpec` test definition to allow `make test` to be interruptible.
 - Adds the `openssl` package (and it's dependency, `make`).
+- Adds `README.md` instruction to use `docker pull` before `docker inspect` on an image.
 
 ### 2.2.0 - 2016-12-19
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,12 @@ If your docker host has systemd, fleetd (and optionally etcd) installed then `sc
 
 Since release tags `1.7.2` / `2.1.2` the install template has been added to the image metadata. Using docker inspect you can access `scmi` to simplify install/uninstall tasks.
 
+_NOTE:_ A prerequisite of the following examples is that the image has been pulled (or loaded from the release package).
+
+```
+$ docker pull jdeathe/centos-ssh:2.2.0
+```
+
 To see detailed information about the image run `scmi` with the `--info` option. To see all available `scmi` options run with the `--help` option.
 
 ```


### PR DESCRIPTION
Resolves #460

- Adds `README.md` instruction to use `docker pull` before `docker inspect` on an image.