### PR TITLE
CLOSES #478: Updates openssh and CentOS-6 version ready for 6.9.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Summary of release changes for Version 2 - CentOS-7
 
+### 2.2.2 - Unlimited
+
+- Updates `openssh` package 6.6.1p1-35.el7_3.
+
 ### 2.2.1 - 2017-02-21
 
 - Updates `vim` and `openssh` packages and the `epel-release`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Summary of release changes for Version 2 - CentOS-7
 
-### 2.2.2 - Unlimited
+### 2.2.2 - Unreleased
 
 - Updates `openssh` package 6.6.1p1-35.el7_3.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,28 +19,30 @@ RUN rpm --rebuilddb \
 	&& rpm --import \
 		https://dl.iuscommunity.org/pub/ius/IUS-COMMUNITY-GPG-KEY \
 	&& yum -y install \
+			--setopt=tsflags=nodocs \
+			--disableplugin=fastestmirror \
 		centos-release-scl \
 		centos-release-scl-rh \
 		epel-release \
 		https://centos7.iuscommunity.org/ius-release.rpm \
-		vim-minimal-7.4.160-1.el7_3.1 \
-		xz-5.2.2-1.el7 \
-		sudo-1.8.6p7-21.el7_3 \
-		openssh-6.6.1p1-33.el7_3 \
-		openssh-server-6.6.1p1-33.el7_3 \
-		openssh-clients-6.6.1p1-33.el7_3 \
-		python-setuptools-0.9.8-4.el7 \
-		yum-plugin-versionlock-1.1.31-40.el7 \
+		openssh-6.6.1p1-35.el7_3 \
+		openssh-server-6.6.1p1-35.el7_3 \
+		openssh-clients-6.6.1p1-35.el7_3 \
 		openssl-1.0.1e-60.el7 \
+		python-setuptools-0.9.8-4.el7 \
+		sudo-1.8.6p7-21.el7_3 \
+		vim-minimal-7.4.160-1.el7_3.1 \
+		yum-plugin-versionlock-1.1.31-40.el7 \
+		xz-5.2.2-1.el7 \
 	&& yum versionlock add \
-		vim-minimal \
-		xz \
-		sudo \
 		openssh \
 		openssh-server \
 		openssh-clients \
 		python-setuptools \
+		sudo \
+		vim-minimal \
 		yum-plugin-versionlock \
+		xz \
 	&& yum clean all \
 	&& rm -rf /etc/ld.so.cache \
 	&& rm -rf /sbin/sln \

--- a/README-short.txt
+++ b/README-short.txt
@@ -1,1 +1,1 @@
-CentOS-6 6.8 x86_64 / CentOS-7 7.3.1611 x86_64 - SCL/EPEL/IUS Repos / Supervisor / OpenSSH.
+CentOS-6 6.9 x86_64 / CentOS-7 7.3.1611 x86_64 - SCL/EPEL/IUS Repos / Supervisor / OpenSSH.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 centos-ssh
 ==========
 
-Docker Images of CentOS-6 6.8 x86_64 / CentOS-7 7.3.1611 x86_64
+Docker Images of CentOS-6 6.9 x86_64 / CentOS-7 7.3.1611 x86_64
 
 Includes public key authentication, Automated password generation and supports custom configuration via environment variables.
 


### PR DESCRIPTION
Resolves #478 

- Updates `openssh` package 6.6.1p1-35.el7_3.