### PR TITLE
CLOSES #473: Replaces deprecated Dockerfile MAINTAINER with a LABEL.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Summary of release changes for Version 2 - CentOS-7
 ### 2.2.2 - Unreleased
 
 - Updates `openssh` package 6.6.1p1-35.el7_3.
+- Replaces deprecated Dockerfile `MAINTAINER` with a `LABEL`.
 
 ### 2.2.1 - 2017-02-21
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,6 @@
 # =============================================================================
 FROM centos:7.3.1611
 
-MAINTAINER James Deathe <james.deathe@gmail.com>
-
 # -----------------------------------------------------------------------------
 # Base Install + Import the RPM GPG keys for Repositories
 # -----------------------------------------------------------------------------
@@ -156,6 +154,7 @@ ENV SSH_AUTHORIZED_KEYS="" \
 # -----------------------------------------------------------------------------
 ARG RELEASE_VERSION="2.2.1"
 LABEL \
+	maintainer="James Deathe <james.deathe@gmail.com>" \
 	install="docker run \
 --rm \
 --privileged \


### PR DESCRIPTION
Resolves #473 

- Replaces deprecated Dockerfile MAINTAINER with a LABEL.