### PR TITLE
CLOSES #481: Replaces deprecated Dockerfile MAINTAINER with a LABEL.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Summary of release changes for Version 1 - CentOS-6
 ### 1.8.0 - Unreleased
 
 - Update source to CentOS-6 6.9.
+- Replaces deprecated Dockerfile `MAINTAINER` with a `LABEL`.
 
 ### 1.7.6 - 2017-02-21
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,6 @@
 # =============================================================================
 FROM centos:centos6.9
 
-MAINTAINER James Deathe <james.deathe@gmail.com>
-
 # -----------------------------------------------------------------------------
 # Base Install + Import the RPM GPG keys for Repositories
 # -----------------------------------------------------------------------------
@@ -167,6 +165,7 @@ ENV SSH_AUTHORIZED_KEYS="" \
 # -----------------------------------------------------------------------------
 ARG RELEASE_VERSION="1.7.6"
 LABEL \
+	maintainer="James Deathe <james.deathe@gmail.com>" \
 	install="docker run \
 --rm \
 --privileged \


### PR DESCRIPTION
Resolves #481 

- Replaces deprecated Dockerfile MAINTAINER with a LABEL.