### PR TITLE
CLOSES #493: Adds STARTUP_TIME for the logs-delayed Makefile target.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Summary of release changes for Version 1 - CentOS-6
 - Replaces deprecated Dockerfile `MAINTAINER` with a `LABEL`.
 - Adds a `src` directory for the image root files.
 - Adds wrapper functions to functional test cases.
+- Adds `STARTUP_TIME` variable for the `logs-delayed` Makefile target.
 
 ### 1.7.6 - 2017-02-21
 

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,8 @@ Targets:
                             DOCKER_IMAGE_TAG variable.
   logs                      Display log output from the running container.
   logs-delayed              Display log output from the running container after
-                            backing off shortly. This can be necessary when 
-                            chaining make targets together.
+                            backing off for STARTUP_TIME seconds. This can be 
+                            necessary when chaining make targets together.
   pause                     Pause the running container.
   pull                      Pull the release image from the registry. Requires 
                             the DOCKER_IMAGE_TAG variable.
@@ -61,6 +61,9 @@ Variables:
                             artifacts are placed.
   - NO_CACHE                When true, no cache will be used while running the 
                             build target.
+  - STARTUP_TIME            Defines the number of seconds expected to complete 
+                            the startup process, including the bootstrap where 
+                            applicable.
 
 endef
 
@@ -357,7 +360,7 @@ logs: _prerequisites
 	@ $(docker) logs $(DOCKER_NAME)
 
 logs-delayed: _prerequisites
-	@ sleep 2
+	@ sleep $(STARTUP_TIME)
 	@ $(MAKE) logs
 
 load: _prerequisites _require-docker-release-tag _require-package-path

--- a/environment.mk
+++ b/environment.mk
@@ -26,6 +26,9 @@ NO_CACHE ?= false
 # Directory path for release packages
 DIST_PATH ?= ./dist
 
+# Number of seconds expected to complete container startup including bootstrap.
+STARTUP_TIME ?= 2
+
 # ------------------------------------------------------------------------------
 # Application container configuration
 # ------------------------------------------------------------------------------

--- a/src/opt/scmi/environment.sh
+++ b/src/opt/scmi/environment.sh
@@ -30,6 +30,9 @@ REGISTER_ETCD_PARAMETERS="${REGISTER_ETCD_PARAMETERS:-}"
 REGISTER_TTL="${REGISTER_TTL:-60}"
 REGISTER_UPDATE_INTERVAL="${REGISTER_UPDATE_INTERVAL:-55}"
 
+# Number of seconds expected to complete container startup including bootstrap.
+STARTUP_TIME="${STARTUP_TIME:-2}"
+
 # Application container configuration
 SSH_AUTHORIZED_KEYS="${SSH_AUTHORIZED_KEYS:-}"
 SSH_AUTOSTART_SSHD="${SSH_AUTOSTART_SSHD:-true}"


### PR DESCRIPTION
Resolves #493

- Adds `STARTUP_TIME` variable for the `logs-delayed` Makefile target.