### PR TITLE
CLOSES #526: Updates supervisor to 3.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Summary of release changes for Version 1 - CentOS-6
 ### 1.8.2 - Unreleased
 
 - Updates [supervisor](http://supervisord.org/changes.html) to version 3.3.3.
+- Updates openssh and sudo to latest versions and remove openssl as upstream has latest.
 
 ### 1.8.1 - 2017-06-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Summary of release changes for Version 1 - CentOS-6
 
+### 1.8.2 - Unreleased
+
+- Updates [supervisor](http://supervisord.org/changes.html) to version 3.3.3.
+
 ### 1.8.1 - 2017-06-14
 
 - Adds clearer, improved [shpec](https://github.com/rylnd/shpec) test case output.

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,12 +23,11 @@ RUN rpm --rebuilddb \
 		centos-release-scl-rh \
 		epel-release \
 		https://centos6.iuscommunity.org/ius-release.rpm \
-		openssh-5.3p1-122.el6 \
-		openssh-clients-5.3p1-122.el6 \
-		openssh-server-5.3p1-122.el6 \
-		openssl-1.0.1e-48.el6_8.3 \
+		openssh-5.3p1-123.el6_9 \
+		openssh-clients-5.3p1-123.el6_9 \
+		openssh-server-5.3p1-123.el6_9 \
 		python-setuptools-0.6.10-3.el6 \
-		sudo-1.8.6p3-27.el6 \
+		sudo-1.8.6p3-29.el6_9 \
 		vim-minimal-7.4.629-5.el6_8.1 \
 		yum-plugin-versionlock-1.1.30-40.el6 \
 		xz-4.999.9-0.5.beta.20091007git.el6.x86_64 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ RUN rpm --rebuilddb \
 # supervisord to be easily inspected with "docker logs".
 # -----------------------------------------------------------------------------
 RUN easy_install \
-		'supervisor == 3.3.2' \
+		'supervisor == 3.3.3' \
 		'supervisor-stdout == 0.1.1' \
 	&& mkdir -p \
 		/var/log/supervisor/


### PR DESCRIPTION
Resolves #526 

- Updates [supervisor](http://supervisord.org/changes.html) to version 3.3.3.
- Updates openssh and sudo to latest versions and remove openssl as upstream has latest.
