### PR TITLE
CLOSES #547: Fixes image build failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Summary of release changes for Version 1 - CentOS-6
 
+### 1.8.3 - Unreleased
+
+- Fixes image build failure caused by error installing supervisor via easy_install.
+
 ### 1.8.2 - 2017-09-13
 
 - Updates [supervisor](http://supervisord.org/changes.html) to version 3.3.3.

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,7 @@ RUN rpm --rebuilddb \
 # supervisord to be easily inspected with "docker logs".
 # -----------------------------------------------------------------------------
 RUN easy_install \
+		--index-url 'https://pypi.python.org/pypi' \
 		'supervisor == 3.3.3' \
 		'supervisor-stdout == 0.1.1' \
 	&& mkdir -p \


### PR DESCRIPTION
Resolves #547 

- Fixes image build failure caused by error installing supervisor via easy_install.