### PR TITLE
CLOSES #544: Patches back #543

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.gitignore
+dist
+test
+LICENSE
+README-short.txt
+*.md
+!README.md
+**/*.mk
+**/Makefile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Summary of release changes for Version 1 - CentOS-6
 ### 1.8.3 - Unreleased
 
 - Fixes image build failure caused by error installing supervisor via easy_install.
+- Adds a `.dockerignore` file.
 
 ### 1.8.2 - 2017-09-13
 


### PR DESCRIPTION
Resolves #544: Patches back #543 to centos-6 branch

- Adds a `.dockerignore` file.



