### PR TITLE
CLOSES #552: Patches back #545.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Summary of release changes for Version 1 - CentOS-6
 
 - Fixes image build failure caused by error installing supervisor via easy_install.
 - Adds a `.dockerignore` file.
+- Deprecates use of the fleet `--manager` option in the `scmi` installer.
 
 ### 1.8.2 - 2017-09-13
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ $ docker run \
 
 ##### SCMI Fleet Support
 
+**_Deprecation Notice:_** The fleet project is no longer maintained. The fleet `--manager` option has been deprecated in `scmi`.
+
 If your docker host has systemd, fleetd (and optionally etcd) installed then `scmi` provides a method to schedule the container  to run on the cluster. This provides some additional features for managing a group of instances on a [fleet](https://github.com/coreos/fleet) cluster and has the option to use an etcd backed service registry. To use the fleet method of installation use the `-m` or `--manager` option of `scmi` and to include the optional etcd register companion unit use the `--register` option.
 
 ##### SCMI Image Information

--- a/src/usr/sbin/scmi
+++ b/src/usr/sbin/scmi
@@ -293,6 +293,10 @@ function scmi ()
 	# Run command for selected service manager
 	case ${SCMI_MANAGER_TYPE} in
 		fleet)
+			scmi_print_message "deprecated" \
+				"The fleet manager is deprecated."
+			scmi_print_message "deprecated_info" \
+				"Consider using the docker or systemd --manager option instead."
 			scmi_fleet_${SCMI_COMMAND}
 			;;
 		systemd)
@@ -1439,6 +1443,7 @@ function scmi_manager_type_command_prerequisites ()
 function scmi_print_message ()
 {
 	local COLOUR_NEGATIVE='\033[1;31m'
+	local COLOUR_NOTICE='\033[1;33m'
 	local COLOUR_POSITIVE='\033[1;32m'
 	local COLOUR_RESET='\033[0m'
 	local CHARACTER_STEP='--->'
@@ -1451,11 +1456,28 @@ function scmi_print_message ()
 	# Allow for uncolourised output
 	if [[ -n ${SCMI_MONOCHROME} ]]; then
 		COLOUR_NEGATIVE=""
+		COLOUR_NOTICE=""
 		COLOUR_POSITIVE=""
 		COLOUR_RESET=""
 	fi
 
 	case "${TYPE}" in
+		deprecated)
+			PREFIX=$(
+				printf -- \
+					'%b%s%b ' \
+					"${COLOUR_NOTICE}" \
+					"[DEPRECATED]" \
+					"${COLOUR_RESET}"
+			)
+			;;
+		deprecated_info)
+			PREFIX=$(
+				printf -- \
+					'%s ' \
+					"            "
+			)
+			;;
 		error)
 			PREFIX=$(
 				printf -- \


### PR DESCRIPTION
Resolves #552: Patches back #545.

- Deprecates use of the fleet `--manager` option in the `scmi` installer.