### PR TITLE
CLOSES #566: Updates python-setuptools.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ Summary of release changes for Version 1 - CentOS-6
 
 ### 1.8.4 - Unreleased
 
-- Updates supervisor to 3.3.4
+- Updates supervisor to 3.3.4.
 - Adds feature to set `SSH_USER_PASSWORD` via a file path. e.g. Docker Swarm secrets.
 - Adds feature to set `SSH_AUTHORIZED_KEYS` via a file path. e.g. Docker Swarm config.
+- Updates python-setuptools to 0.6.10-4el6_9. Removes workaround for easy_install failure.
 
 ### 1.8.3 - 2018-01-12
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN rpm --rebuilddb \
 		openssh-5.3p1-123.el6_9 \
 		openssh-clients-5.3p1-123.el6_9 \
 		openssh-server-5.3p1-123.el6_9 \
-		python-setuptools-0.6.10-3.el6 \
+		python-setuptools-0.6.10-4el6_9 \
 		sudo-1.8.6p3-29.el6_9 \
 		vim-minimal-7.4.629-5.el6_8.1 \
 		yum-plugin-versionlock-1.1.30-40.el6 \
@@ -65,7 +65,6 @@ RUN rpm --rebuilddb \
 # supervisord to be easily inspected with "docker logs".
 # -----------------------------------------------------------------------------
 RUN easy_install \
-		--index-url 'https://pypi.python.org/pypi' \
 		'supervisor == 3.3.4' \
 		'supervisor-stdout == 0.1.1' \
 	&& mkdir -p \


### PR DESCRIPTION
CLOSES #566

- Updates python-setuptools to 0.6.10-4el6_9. Removes workaround for easy_install failure.