### PR TITLE
CLOSES #576: Removes vim-minimal from yum versionlock.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@ RUN rpm --rebuilddb \
 		centos-release-scl-rh \
 		epel-release \
 		https://centos6.iuscommunity.org/ius-release.rpm \
-		openssh-5.3p1-123.el6_9 \
 		openssh-clients-5.3p1-123.el6_9 \
 		openssh-server-5.3p1-123.el6_9 \
 		python-setuptools-0.6.10-4.el6_9 \
@@ -36,7 +35,6 @@ RUN rpm --rebuilddb \
 		openssh-server \
 		python-setuptools \
 		sudo \
-		vim-minimal \
 		yum-plugin-versionlock \
 		xz \
 	&& rpm -e --nodeps \


### PR DESCRIPTION
CLOSES #576 

- Removes vim-minimal from yum versionlock.