### PR TITLE
CLOSES #570: Adds explicit user (root) for running supervisord.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Summary of release changes for Version 2 - CentOS-7
 ### 2.4.0 - Unreleased
 
 - Updates source tag to CentOS 7.5.1804.
+- Adds explicit user (root) for running `supervisord`.
 
 ### 2.3.2 - 2018-04-24
 

--- a/src/etc/services-config/supervisor/supervisord.conf
+++ b/src/etc/services-config/supervisor/supervisord.conf
@@ -7,6 +7,7 @@ pidfile = /var/run/supervisord.pid
 minfds = 1024
 minprocs = 200
 nodaemon = true
+user = root
 
 [eventlistener:supervisor_stdout]
 command = /usr/bin/supervisor_stdout


### PR DESCRIPTION
CLOSES #570 

- Adds explicit user (root) for running `supervisord`.