### PR TITLE
CLOSES #571: Patches back #570.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Summary of release changes for Version 1 - CentOS-6
 ### 1.9.0 - Unreleased
 
 - Update source to CentOS-6 6.10.
+- Adds explicit user (root) for running `supervisord`.
 
 ### 1.8.4 - 2018-04-24
 

--- a/src/etc/services-config/supervisor/supervisord.conf
+++ b/src/etc/services-config/supervisor/supervisord.conf
@@ -7,6 +7,7 @@ pidfile = /var/run/supervisord.pid
 minfds = 1024
 minprocs = 200
 nodaemon = true
+user = root
 
 [eventlistener:supervisor_stdout]
 command = /usr/bin/supervisor_stdout


### PR DESCRIPTION
CLOSES #571: Patches back #570 

- Adds explicit user (root) for running `supervisord`.