### PR TITLE
CLOSES #598: Allows SSH_USER_ID values in the system ID range.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Summary of release changes for Version 1 - CentOS-6
 ### 1.9.2 - Unreleased
 
 - Fixes bootstrap errors regarding readonly `PASSWORD_LENGTH`.
+- Updates validation for `SSH_USER_ID` to allow values in the system ID range.
 
 ### 1.9.1 - 2018-11-10
 

--- a/README.md
+++ b/README.md
@@ -470,7 +470,9 @@ On first run the SSH user is created with a default shell of "/bin/bash". If you
 
 ##### SSH_USER_ID
 
-Use `SSH_USER_ID` to set a specific UID:GID for the `SSH_USER`. The values should be 500 or more - the default being 500:500. This may be useful when running an SFTP container and mounting data volumes from an existing container.
+Use `SSH_USER_ID` to set a specific UID:GID for the `SSH_USER`. The values should be 500 or more for non system users - the default being 500:500. Using values in the range 2-499 is possible but should be used with caution as these values may conflict with existing system accounts.
+
+This may be useful when running an SFTP container and mounting data volumes from an existing container.
 
 ```
 ...

--- a/src/usr/sbin/sshd-bootstrap
+++ b/src/usr/sbin/sshd-bootstrap
@@ -166,10 +166,10 @@ function is_valid_ssh_user_shell ()
 function is_valid_ssh_user_id ()
 {
 	local -r id="${1}"
-	local -r id_pattern='^([0-9]{3,}):([0-9]{3,})$'
+	local -r id_pattern='^([0-9]{1,}):([0-9]{1,})$'
 
-	local group_id=500
-	local user_id=500
+	local group_id=1
+	local user_id=1
 
 	if [[ -z ${id} ]]
 	then
@@ -181,7 +181,7 @@ function is_valid_ssh_user_id ()
 		user_id="${BASH_REMATCH[1]}"
 		group_id="${BASH_REMATCH[2]}"
 
-		if (( user_id >= 500 )) && (( group_id >= 500 ))
+		if (( user_id >= 2 )) && (( group_id >= 2 ))
 		then
 			return 0
 		fi
@@ -451,7 +451,7 @@ function get_ssh_user_uid ()
 	local -r id="$(
 		get_ssh_user_id
 	)"
-	local -r id_pattern='^([0-9]{3,}):([0-9]{3,})$'
+	local -r id_pattern='^([0-9]{1,}):([0-9]{1,})$'
 
 	local value="${default_value}"
 
@@ -483,7 +483,7 @@ function get_ssh_user_gid ()
 	local -r id="$(
 		get_ssh_user_id
 	)"
-	local -r id_pattern='^([0-9]{3,}):([0-9]{3,})$'
+	local -r id_pattern='^([0-9]{1,}):([0-9]{1,})$'
 
 	local value="${default_value}"
 


### PR DESCRIPTION
CLOSES #598, #596, #472

- Updates validation for `SSH_USER_ID` to allow values in the system ID range.