### PR TITLE
CLOSES #646: Replaces awk with native bash regex.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Summary of release changes for Version 2 - CentOS-7
 - Updates and restructures Dockerfile to reduce number of layers in image.
 - Updates container naming conventions for `scmi` making the node element optional.
 - Updates container naming conventions and readability of `Makefile`.
+- Replaces awk with native bash regex when testing sudo user's have `NOPASSWD:ALL`.
 - Fixes bootstrap errors regarding readonly `PASSWORD_LENGTH`.
 - Fixes issue with redacted password when using `SSH_PASSWORD_AUTHENTICATION` in combination with `SSH_USER_FORCE_SFTP`.
 - Adds `SSH_USER_PRIVATE_KEY` to allow configuration of an RSA private key for `SSH_USER`.

--- a/src/usr/sbin/sshd-bootstrap
+++ b/src/usr/sbin/sshd-bootstrap
@@ -21,14 +21,9 @@ source /etc/sshd-bootstrap.conf
 function is_sudo_no_password_all ()
 {
 	local -r sudo="${1}"
+	local -r pattern=' ?NOPASSWD:ALL$'
 
-	if [[ -z ${sudo} ]]
-	then
-		return 1
-	fi
-
-	if [[ -n $(echo "${sudo}" \
-		| awk -v pattern="NOPASSWD:ALL" '$NF ~ pattern { print $0; }') ]]
+	if [[ ${sudo} =~ ${pattern} ]]
 	then
 		return 0
 	fi

--- a/src/usr/sbin/sshd-bootstrap
+++ b/src/usr/sbin/sshd-bootstrap
@@ -141,11 +141,6 @@ function is_valid_ssh_user_password_hash ()
 	local -r password_hash="${1}"
 	local -r sha_512_pattern='^\$6\$[a-zA-Z0-9./]{0,16}\$[a-zA-Z0-9./]{86}$'
 
-	if [[ -z ${password_hash} ]]
-	then
-		return 1
-	fi
-
 	if [[ ${password_hash} =~ ${sha_512_pattern} ]]
 	then
 		return 0
@@ -186,11 +181,6 @@ function is_valid_ssh_user_id ()
 
 	local group_id=1
 	local user_id=1
-
-	if [[ -z ${id} ]]
-	then
-		return 1
-	fi
 
 	if [[ ${id} =~ ${id_pattern} ]]
 	then


### PR DESCRIPTION
CLOSES #646

- Replaces awk with native bash regex when testing sudo user's have `NOPASSWD:ALL`.