### PR TITLE
CLOSES #659: Attempt to fix issues intermittent test failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Summary of release changes for Version 1 - CentOS-6
 - Adds `SSH_USER_PRIVATE_KEY` to allow configuration of an RSA private key for `SSH_USER`.
 - Adds placeholder replacement of `RELEASE_VERSION` docker argument to systemd service unit template.
 - Adds error messages to healthcheck script and includes supervisord check.
+- Adds `__docker_logs_match` function to test cases to work-around output delays on CI service's host.
 - Removes use of `/etc/services-config` paths.
 - Removes fleet `--manager` option in the `scmi` installer.
 - Removes X-Fleet section from etcd register template unit-file.


### PR DESCRIPTION
#559: Patches back #658.

- Adds `__docker_logs_match` function to test cases to work-around output delays on CI service's host.