### PR TITLE
CLOSES #655: Fixes port incrementation in run templates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,12 @@ Summary of release changes for Version 1 - CentOS-6
 - Replaces awk with native bash regex when testing sudo user's have `NOPASSWD:ALL`.
 - Fixes bootstrap errors regarding readonly `PASSWORD_LENGTH`.
 - Fixes issue with redacted password when using `SSH_PASSWORD_AUTHENTICATION` in combination with `SSH_USER_FORCE_SFTP`.
+- Fixes issue with unexpected published port in run templates when `DOCKER_PORT_MAP_TCP_22` is set to an empty string or 0.
 - Adds `SSH_USER_PRIVATE_KEY` to allow configuration of an RSA private key for `SSH_USER`.
 - Adds placeholder replacement of `RELEASE_VERSION` docker argument to systemd service unit template.
 - Adds error messages to healthcheck script and includes supervisord check.
 - Adds `__docker_logs_match` function to test cases to work-around output delays on CI service's host.
+- Adds port incrementation to Makefile's run template for container names with an instance suffix.
 - Removes use of `/etc/services-config` paths.
 - Removes fleet `--manager` option in the `scmi` installer.
 - Removes X-Fleet section from etcd register template unit-file.

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ Variables:
   - DOCKER_IMAGE_TAG        Defines the image tag name.
   - DOCKER_NAME             Container name. The required format is as follows
                             where <instance> and <node> are numeric values.
-                            <name>.<instance>[.<node>]
+                            <name>[.<instance>[.<node>]]
   - DOCKER_PORT_MAP_TCP_*   The port map variable is used to define the initial
                             port mapping to use for the docker host value where
                             "*" corresponds to an exposed port on the container.

--- a/default.mk
+++ b/default.mk
@@ -1,4 +1,42 @@
 
+# Handle incrementing the docker host port for instances unless a port range is defined.
+DOCKER_PUBLISH := $(shell \
+	if [[ "$(DOCKER_PORT_MAP_TCP_22)" != NULL ]]; \
+	then \
+		if grep -qE \
+				'^([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}:)?[1-9][0-9]*$$' \
+				<<< "$(DOCKER_PORT_MAP_TCP_22)" \
+			&& grep -qE \
+				'^.+\.[0-9]+(\.[0-9]+)?$$' \
+				<<< "$(DOCKER_NAME)"; \
+		then \
+			printf -- ' --publish %s%s:22' \
+				"$$(\
+					grep -o '^[0-9\.]*:' \
+						<<< "$(DOCKER_PORT_MAP_TCP_22)" \
+				)" \
+				"$$(( \
+					$$(\
+						grep -oE \
+							'[0-9]+$$' \
+							<<< "$(DOCKER_PORT_MAP_TCP_22)" \
+					) \
+					+ $$(\
+						grep -oE \
+							'([0-9]+)(\.[0-9]+)?$$' \
+							<<< "$(DOCKER_NAME)" \
+						| awk -F. \
+							'{ print $$1; }' \
+					) \
+					- 1 \
+				))"; \
+		else \
+			printf -- ' --publish %s:22' \
+				"$(DOCKER_PORT_MAP_TCP_22)"; \
+		fi; \
+	fi; \
+)
+
 # Common parameters of create and run targets
 define DOCKER_CONTAINER_PARAMETERS
 --name $(DOCKER_NAME) \
@@ -19,11 +57,3 @@ define DOCKER_CONTAINER_PARAMETERS
 --env "SSH_USER_PRIVATE_KEY=$(SSH_USER_PRIVATE_KEY)" \
 --env "SSH_USER_SHELL=$(SSH_USER_SHELL)"
 endef
-
-DOCKER_PUBLISH := $(shell \
-	if [[ $(DOCKER_PORT_MAP_TCP_22) != NULL ]]; \
-	then \
-		printf -- '--publish %s:22\n' \
-			$(DOCKER_PORT_MAP_TCP_22); \
-	fi; \
-)

--- a/src/etc/systemd/system/centos-ssh@.service
+++ b/src/etc/systemd/system/centos-ssh@.service
@@ -153,17 +153,31 @@ ExecStart=/bin/bash -c \
     --env \"SSH_USER_SHELL=${SSH_USER_SHELL}\" \
     $(if [[ ${DOCKER_PORT_MAP_TCP_22} != NULL ]]; \
     then \
-      if /usr/bin/grep \
-          -qE '^([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}:)?[0-9]+$' \
+      if /usr/bin/grep -qE \
+          '^([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}:)?[1-9][0-9]*$' \
           <<< \"${DOCKER_PORT_MAP_TCP_22}\"; \
+        && /usr/bin/grep -qE \
+          '^.+\.[0-9]+(\.[0-9]+)?$' \
+          <<< "${DOCKER_NAME}"
       then \
         printf -- '--publish %%s%%s:22' \
-          $(/usr/bin/grep -o '^[0-9\.]*:' <<< \"${DOCKER_PORT_MAP_TCP_22}\") \
-          $(( $(/usr/bin/grep -oE '[0-9]+$' \
-                  <<< \"${DOCKER_PORT_MAP_TCP_22}\" \
-              ) \
-              + $(/usr/bin/grep -oE '^[0-9]+' <<< %i) \
-              - 1 \
+          $(\
+            /usr/bin/grep -o \
+              '^[0-9\.]*:' \
+              <<< \"${DOCKER_PORT_MAP_TCP_22}\" \
+          ) \
+          $(( \
+            $(\
+              /usr/bin/grep -oE \
+                '[0-9]+$' \
+                <<< \"${DOCKER_PORT_MAP_TCP_22}\" \
+            ) \
+            + $(\
+              /usr/bin/grep -oE \
+                '^[0-9]+' \
+                <<< %i \
+            ) \
+            - 1 \
           )); \
       else \
         printf -- '--publish %%s:22' \

--- a/src/opt/scmi/default.sh
+++ b/src/opt/scmi/default.sh
@@ -3,9 +3,11 @@
 DOCKER_PUBLISH=
 if [[ ${DOCKER_PORT_MAP_TCP_22} != NULL ]]
 then
-	if grep -qE '^([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}:)?[0-9]+$' \
+	if grep -qE \
+			'^([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}:)?[1-9][0-9]*$' \
 			<<< "${DOCKER_PORT_MAP_TCP_22}" \
-		&& grep -qE '^.+\.[0-9]+(\.[0-9]+)?$' \
+		&& grep -qE \
+			'^.+\.[0-9]+(\.[0-9]+)?$' \
 			<<< "${DOCKER_NAME}"
 	then
 		printf -v \
@@ -13,18 +15,22 @@ then
 			-- '%s --publish %s%s:22' \
 			"${DOCKER_PUBLISH}" \
 			"$(
-				grep -o '^[0-9\.]*:' \
+				grep -o \
+					'^[0-9\.]*:' \
 					<<< "${DOCKER_PORT_MAP_TCP_22}"
 			)" \
 			"$(( 
 				$(
-					grep -oE '[0-9]+$' \
+					grep -oE \
+						'[0-9]+$' \
 						<<< "${DOCKER_PORT_MAP_TCP_22}"
 				) \
 				+ $(
-					grep -oE '([0-9]+)(\.[0-9]+)?$' \
+					grep -oE \
+						'([0-9]+)(\.[0-9]+)?$' \
 						<<< "${DOCKER_NAME}" \
-					| awk -F. '{ print $1; }'
+					| awk -F. \
+						'{ print $1; }'
 				) \
 				- 1
 			))"


### PR DESCRIPTION
CLOSES #655: Patches back #654.

- Fixes issue with unexpected published port in run templates when `DOCKER_PORT_MAP_TCP_22` is set to an empty string or 0.
- Adds port incrementation to Makefile's run template for container names with an instance suffix.