### PR TITLE
CLOSES #662: Improves reliability of test cases on CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Summary of release changes for Version 2 - CentOS-7
 - Updates container naming conventions and readability of `Makefile`.
 - Updates `docker logs` output example in README document.
 - Updates README instructions following review.
+- Updates default HEALTHCHECK interval to 1 second from 0.5.
 - Replaces awk with native bash regex when testing sudo user's have `NOPASSWD:ALL`.
 - Fixes bootstrap errors regarding readonly `PASSWORD_LENGTH`.
 - Fixes issue with redacted password when using `SSH_PASSWORD_AUTHENTICATION` in combination with `SSH_USER_FORCE_SFTP`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Summary of release changes for Version 2 - CentOS-7
 - Adds error messages to healthcheck script and includes supervisord check.
 - Adds `__docker_logs_match` function to test cases to work-around output delays on CI service's host.
 - Adds port incrementation to Makefile's run template for container names with an instance suffix.
+- Adds consideration for event lag into test cases for unhealthy health_status events.
 - Removes use of `/etc/services-config` paths.
 - Removes fleet `--manager` option in the `scmi` installer.
 - Removes X-Fleet section from etcd register template unit-file.

--- a/Dockerfile
+++ b/Dockerfile
@@ -148,7 +148,7 @@ jdeathe/centos-ssh:${RELEASE_VERSION} \
 	org.deathe.description="CentOS-7 7.5.1804 x86_64 - SCL, EPEL and IUS Repositories / Supervisor / OpenSSH."
 
 HEALTHCHECK \
-	--interval=0.5s \
+	--interval=1s \
 	--timeout=1s \
 	--retries=5 \
 	CMD ["/usr/bin/healthcheck"]

--- a/test/health_status
+++ b/test/health_status
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+
+function __cleanup ()
+{
+	local -r fifo_path="${1:-}"
+	local -r pid="${2:-0}"
+
+	if [[ -p ${fifo_path} ]]
+	then
+		rm -f "${fifo_path}"
+	fi
+
+	if (( ${pid} <= 1 ))
+	then
+		return 0
+	fi
+
+	kill \
+		-15 \
+		-- ${pid} \
+		> /dev/null \
+		2>&1
+}
+
+function __print_status ()
+{
+	local -r character_positive='✓'
+	local -r character_negative='✗'
+	local colour_negative='\033[1;31m'
+	local colour_positive='\033[1;32m'
+	local colour_reset='\033[0m'
+	local type="${1:-}"
+	local message="${2:-${type}}"
+
+	if [[ ${option_quiet} == true ]]
+	then
+		return 0
+	fi
+
+	# Allow for uncolourised output
+	if [[ ${option_monochrome} == true ]]
+	then
+		unset \
+			colour_negative \
+			colour_notice \
+			colour_positive \
+			colour_reset
+	fi
+
+	case "${type}" in
+		healthy|starting)
+			printf -- \
+				'%b%s%b %s\n' \
+				"${colour_positive}" \
+				"${character_positive}" \
+				"${colour_reset}" \
+				"${message}"
+			;;
+		timeout|unhealthy)
+			printf -- \
+				'%b%s%b %s\n' \
+				"${colour_negative}" \
+				"${character_negative}" \
+				"${colour_reset}" \
+				"${message}" \
+				>&2
+			;;
+	esac
+}
+
+function __usage()
+{
+	cat <<-EOF
+	Usage: $(basename ${0}) -c <name or id> [OPTIONS]
+	       $(basename ${0}) --container=<name or id> [OPTIONS]
+	       $(basename ${0}) [-h|--help]
+
+	Gets health_status events and returns the status.
+
+	Options:
+	  -c, --container=NAME       Container name or id.
+	  -h, --help                 Show this help and exit.
+	  --monochrome               Output colour is suppressed.
+	  -q, --quiet                Display less message output except for errors.
+	  --since=TIMESTAMP          Unix timestamp from which to limit events.
+	                             Defaults to start time.
+	  -t, --timeout=SECONDS      Timeout value in seconds. Defaults to 10.
+	                             Set to 0 for no timeout.
+	EOF
+
+	exit 1
+}
+
+function health_status ()
+{
+	local -r fifo_path="$(
+		mktemp -u
+	)"
+	local -r pattern_healthy='^health_status: healthy$'
+	local -r pattern_starting='^health_status: starting$'
+	local -r pattern_timeout='^[0-9]+$'
+	local -r pattern_timestamp='^[0-9]{10}$'
+	local -r pattern_unhealthy='^health_status: unhealthy$'
+
+	option_monochrome=false
+	option_quiet=false
+	local container
+	local events_command
+	local health_status
+	local pid
+	local since
+	local since_timestamp="$(
+		date +%s
+	)"
+	local timeout=10
+	local until_timestamp
+	local until
+
+	# Parse install options
+	while [[ "${#}" -gt 0 ]]
+	do
+		case "${1}" in
+			-h|--help)
+				__usage
+				break
+				;;
+			--monochrome)
+				option_monochrome=true
+				shift 1
+				;;
+			-c)
+				if [[ -z ${2:-} ]]
+				then
+					__usage
+				fi
+				container="${2:-}"
+				shift 2
+				;;
+			--container=*)
+				container="${1#*=}"
+				shift 1
+				;;
+			-q|--quiet)
+				option_quiet=true
+				shift 1
+				;;
+			--since=*)
+				since_timestamp="${1#*=}"
+				shift 1
+				;;
+			-t)
+				if [[ -z ${2:-} ]]
+				then
+					__usage
+				fi
+				timeout="${2:-}"
+				shift 2
+				;;
+			--timeout=*)
+				timeout="${1#*=}"
+				shift 1
+				;;
+			*)
+				__usage
+				;;
+		esac
+	done
+
+	if [[ -z ${container} ]]
+	then
+		__usage
+	fi
+
+	if ! [[ ${timeout} =~ ${pattern_timeout} ]]
+	then
+		printf -- \
+			'[ERROR] Invalid --time value.\n' \
+			>&2
+		__usage
+	fi
+
+	# Set end time limit
+	until=""
+	if (( timeout > 0 ))
+	then
+		until_timestamp="$((
+			$(
+				date +%s
+			)
+			+ ${timeout}
+		))"
+
+		until="$(
+			printf -- \
+				'--until %s' \
+				"${until_timestamp}"
+		)"
+	fi
+
+	# Fail if operator attempts start time limit before end limit.
+	if ! [[ ${since_timestamp} =~ ${pattern_timestamp} ]] \
+		|| (( since_timestamp > until_timestamp ))
+	then
+		printf -- \
+			'[ERROR] Invalid --since value.\n' \
+			>&2
+		__usage
+	fi
+
+	# Set start time limit
+	since="$(
+		printf -- \
+			'--since %s' \
+			"${since_timestamp}"
+	)"
+
+	trap \
+		"__cleanup \"${fifo_path}\"" \
+		INT TERM EXIT
+
+	mkfifo \
+		-m 0600 \
+		"${fifo_path}"
+
+	docker events \
+		--format '{{.Status}}' \
+		--filter "event=health_status" \
+		--filter "container=${container}" \
+		${since} \
+		${until} \
+		> "${fifo_path}" \
+	&
+	pid="${!}"
+	disown
+
+	trap \
+		"__cleanup \"${fifo_path}\" \"${pid}\"" \
+		INT TERM EXIT
+
+	while IFS= read -r health_status || [[ -n ${health_status} ]]
+	do
+		if [[ ${health_status} =~ ${pattern_starting} ]]
+		then
+			__print_status "starting"
+		fi
+
+		if [[ ${health_status} =~ ${pattern_healthy} ]]
+		then
+			__print_status "healthy"
+			return 0
+		fi
+	
+		if [[ ${health_status} =~ ${pattern_unhealthy} ]]
+		then
+			__print_status "unhealthy"
+			return 1
+		fi
+	done < "${fifo_path}"
+
+	__print_status "timeout"
+	return 1
+}
+
+health_status "${@}"

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -213,7 +213,7 @@ function test_basic_ssh_operations ()
 
 		describe "SSH user's password"
 			password="$(
-				docker logs \
+				__docker_logs_match \
 					ssh.1 \
 				| awk '/^password :.*$/ { print $3; }'
 			)"
@@ -618,7 +618,7 @@ function test_custom_ssh_configuration ()
 
 			it "Logs the setting value."
 				user_sudo="$(
-					docker logs \
+					__docker_logs_match \
 						ssh.1 \
 					| awk '/^sudo :.*$/ { print $0; }'
 				)"
@@ -680,7 +680,7 @@ function test_custom_ssh_configuration ()
 
 			it "Logs the setting value."
 				user="$(
-					docker logs \
+					__docker_logs_match \
 						ssh.1 \
 					| awk '/^user :.*$/ { print $0; }'
 				)"
@@ -834,7 +834,7 @@ function test_custom_ssh_configuration ()
 
 				it "Logs the key signatures."
 					user_key_signature="$(
-						docker logs \
+						__docker_logs_match \
 							ssh.1 \
 						| awk '/^45:46:b0:ef:a5:e3:c9:6f:1e:66:94:ba:e1:fd:df:65$/ { print $1; }'
 					)"
@@ -919,7 +919,7 @@ function test_custom_ssh_configuration ()
 
 				it "Logs the key signatures."
 					user_key_signature="$(
-						docker logs \
+						__docker_logs_match \
 							ssh.1 \
 						| awk '/^45:46:b0:ef:a5:e3:c9:6f:1e:66:94:ba:e1:fd:df:65$/ { print $1; }'
 					)"
@@ -1110,7 +1110,7 @@ function test_custom_ssh_configuration ()
 
 			it "Logs the setting value."
 				user_home="$(
-					docker logs \
+					__docker_logs_match \
 						ssh.1 \
 					| awk '/^home :.*$/ { print $0; }'
 				)"
@@ -1173,7 +1173,7 @@ function test_custom_ssh_configuration ()
 
 			it "Logs the setting value."
 				user_id="$(
-					docker logs \
+					__docker_logs_match \
 						ssh.1 \
 					| awk '/^id :.*$/ { print $0; }'
 				)"
@@ -1236,7 +1236,7 @@ function test_custom_ssh_configuration ()
 
 			it "Logs the setting value."
 				user_id="$(
-					docker logs \
+					__docker_logs_match \
 						ssh.1 \
 					| awk '/^id :.*$/ { print $0; }'
 				)"
@@ -1300,7 +1300,7 @@ function test_custom_ssh_configuration ()
 
 			it "Logs the setting value."
 				user_shell="$(
-					docker logs \
+					__docker_logs_match \
 						ssh.1 \
 					| awk '/^shell :.*$/ { print $0; }'
 				)"
@@ -1417,7 +1417,7 @@ function test_custom_ssh_configuration ()
 
 			it "Logs a redacted value."
 				user_password="$(
-					docker logs \
+					__docker_logs_match \
 						ssh.1 \
 					| awk '/^password :.*$/ { print $0; }'
 				)"
@@ -1489,7 +1489,7 @@ function test_custom_ssh_configuration ()
 
 			it "Logs a redacted value."
 				user_password="$(
-					docker logs \
+					__docker_logs_match \
 						ssh.1 \
 					| awk '/^password :.*$/ { print $0; }'
 				)"
@@ -1561,7 +1561,7 @@ function test_custom_ssh_configuration ()
 
 			it "Logs a redacted value."
 				user_password="$(
-					docker logs \
+					__docker_logs_match \
 						ssh.1 \
 					| awk '/^password :.*$/ { print $0; }'
 				)"
@@ -1630,7 +1630,7 @@ function test_custom_ssh_configuration ()
 
 			it "Logs a redacted value."
 				user_password="$(
-					docker logs \
+					__docker_logs_match \
 						ssh.1 \
 					| awk '/^password :.*$/ { print $0; }'
 				)"
@@ -1680,7 +1680,7 @@ function test_custom_ssh_configuration ()
 
 			it "Logs the setting value."
 				timezone="$(
-					docker logs \
+					__docker_logs_match \
 						ssh.1 \
 					| awk '/^timezone :.*$/ { print $0; }'
 				)"
@@ -1707,7 +1707,7 @@ function test_custom_ssh_configuration ()
 			sleep ${STARTUP_TIME}
 
 			it "Can disable sshd-bootstrap."
-				docker logs \
+				__docker_logs_match \
 					ssh.1 \
 				| grep -qE 'INFO success: sshd-bootstrap entered RUNNING state'
 
@@ -1839,7 +1839,7 @@ function test_custom_sftp_configuration ()
 
 			it "Logs the setting value."
 				password_authentication="$(
-					docker logs \
+					__docker_logs_match \
 						sftp.1 \
 					| awk '/^password authentication :.*$/ { print $0; }'
 				)"
@@ -1903,7 +1903,7 @@ function test_custom_sftp_configuration ()
 
 			it "Logs the setting value."
 				chroot_path="$(
-					docker logs \
+					__docker_logs_match \
 						sftp.1 \
 					| awk '/^chroot path :.*$/ { print $0; }'
 				)"

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -22,7 +22,7 @@ function __destroy ()
 
 function __docker_logs_match ()
 {
-	local -r logs_lag_seconds=3
+	local -r logs_lag_seconds=6
 	local -r container="${1:-}"
 	local -r pattern="${2:-"INFO exited: .*expected"}"
 
@@ -36,7 +36,7 @@ function __docker_logs_match ()
 	then
 		return 1
 	fi
-
+set -x
 	until (( counter == 0 ))
 	do
 		sleep 1
@@ -52,7 +52,7 @@ function __docker_logs_match ()
 
 		(( counter -= 1 ))
 	done
-
+set +x
 	printf -- \
 		'%s' \
 		"${value}"

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -22,7 +22,7 @@ function __destroy ()
 
 function __docker_logs_match ()
 {
-	local -r logs_lag_seconds=2
+	local -r logs_lag_seconds=3
 	local -r container="${1:-}"
 	local -r pattern="${2:-"INFO exited: .*expected"}"
 

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -1703,7 +1703,16 @@ function test_custom_ssh_configuration ()
 				jdeathe/centos-ssh:latest \
 			&> /dev/null
 
-			sleep ${STARTUP_TIME}
+			if ! __is_container_ready \
+				ssh.1 \
+				${STARTUP_TIME} \
+				"/usr/sbin/sshd " \
+				"grep \
+					'^Server listening on 0\.0\.0\.0 port 22\.' \
+					/var/log/secure"
+			then
+				exit 1
+			fi
 
 			it "Can disable sshd-bootstrap."
 				docker logs \

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -22,10 +22,14 @@ function __destroy ()
 
 function __docker_logs_match ()
 {
+	local -r logs_lag_seconds=2
 	local -r container="${1:-}"
 	local -r pattern="${2:-"INFO exited: .*expected"}"
 
-	local counter="${3:-${STARTUP_TIME}}"
+	local counter="$((
+		${logs_lag_seconds}
+		+ ${3:-${STARTUP_TIME}}
+	))"
 	local value
 
 	if [[ -z ${container} ]]

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -22,27 +22,22 @@ function __destroy ()
 
 function __docker_logs_match ()
 {
-	local -r logs_lag_seconds=6
-	local -r container="${1:-}"
-	local -r pattern="${2:-"INFO exited: .*expected"}"
+	local -r pattern="${2:-'INFO exited: .*expected'}"
 
-	local counter="$((
-		${logs_lag_seconds}
-		+ ${3:-${STARTUP_TIME}}
-	))"
-	local value
+	local counter="${3:-${STARTUP_TIME}}"
+	local value=""
 
 	if [[ -z ${container} ]]
 	then
 		return 1
 	fi
-set -x
+
 	until (( counter == 0 ))
 	do
 		sleep 1
 
 		value="$(
-			docker logs "${container}"
+			docker logs ${1:-}
 		)"
 
 		if [[ ${value} =~ ${pattern} ]]
@@ -52,7 +47,7 @@ set -x
 
 		(( counter -= 1 ))
 	done
-set +x
+
 	printf -- \
 		'%s' \
 		"${value}"
@@ -217,7 +212,7 @@ function test_basic_ssh_operations ()
 
 		describe "SSH user's password"
 			password="$(
-				__docker_logs_match \
+				docker logs \
 					ssh.1 \
 				| awk '/^password :.*$/ { print $3; }'
 			)"
@@ -622,7 +617,7 @@ function test_custom_ssh_configuration ()
 
 			it "Logs the setting value."
 				user_sudo="$(
-					__docker_logs_match \
+					docker logs \
 						ssh.1 \
 					| awk '/^sudo :.*$/ { print $0; }'
 				)"
@@ -684,7 +679,7 @@ function test_custom_ssh_configuration ()
 
 			it "Logs the setting value."
 				user="$(
-					__docker_logs_match \
+					docker logs \
 						ssh.1 \
 					| awk '/^user :.*$/ { print $0; }'
 				)"
@@ -838,7 +833,7 @@ function test_custom_ssh_configuration ()
 
 				it "Logs the key signatures."
 					user_key_signature="$(
-						__docker_logs_match \
+						docker logs \
 							ssh.1 \
 						| awk '/^45:46:b0:ef:a5:e3:c9:6f:1e:66:94:ba:e1:fd:df:65$/ { print $1; }'
 					)"
@@ -923,7 +918,7 @@ function test_custom_ssh_configuration ()
 
 				it "Logs the key signatures."
 					user_key_signature="$(
-						__docker_logs_match \
+						docker logs \
 							ssh.1 \
 						| awk '/^45:46:b0:ef:a5:e3:c9:6f:1e:66:94:ba:e1:fd:df:65$/ { print $1; }'
 					)"
@@ -990,7 +985,7 @@ function test_custom_ssh_configuration ()
 
 				it "Logs the key signature."
 					user_key_signature="$(
-						__docker_logs_match \
+						docker logs \
 							ssh.1 \
 						| sed -n -e '/^rsa private key fingerprint :$/{ n; p; }' \
 						| awk '{ print $1; }'
@@ -1049,7 +1044,7 @@ function test_custom_ssh_configuration ()
 
 				it "Logs the key signature."
 					user_key_signature="$(
-						__docker_logs_match \
+						docker logs \
 							ssh.1 \
 						| sed -n -e '/^rsa private key fingerprint :$/{ n; p; }' \
 						| awk '{ print $1; }'
@@ -1114,7 +1109,7 @@ function test_custom_ssh_configuration ()
 
 			it "Logs the setting value."
 				user_home="$(
-					__docker_logs_match \
+					docker logs \
 						ssh.1 \
 					| awk '/^home :.*$/ { print $0; }'
 				)"
@@ -1177,7 +1172,7 @@ function test_custom_ssh_configuration ()
 
 			it "Logs the setting value."
 				user_id="$(
-					__docker_logs_match \
+					docker logs \
 						ssh.1 \
 					| awk '/^id :.*$/ { print $0; }'
 				)"
@@ -1240,7 +1235,7 @@ function test_custom_ssh_configuration ()
 
 			it "Logs the setting value."
 				user_id="$(
-					__docker_logs_match \
+					docker logs \
 						ssh.1 \
 					| awk '/^id :.*$/ { print $0; }'
 				)"
@@ -1304,7 +1299,7 @@ function test_custom_ssh_configuration ()
 
 			it "Logs the setting value."
 				user_shell="$(
-					__docker_logs_match \
+					docker logs \
 						ssh.1 \
 					| awk '/^shell :.*$/ { print $0; }'
 				)"
@@ -1421,7 +1416,7 @@ function test_custom_ssh_configuration ()
 
 			it "Logs a redacted value."
 				user_password="$(
-					__docker_logs_match \
+					docker logs \
 						ssh.1 \
 					| awk '/^password :.*$/ { print $0; }'
 				)"
@@ -1493,7 +1488,7 @@ function test_custom_ssh_configuration ()
 
 			it "Logs a redacted value."
 				user_password="$(
-					__docker_logs_match \
+					docker logs \
 						ssh.1 \
 					| awk '/^password :.*$/ { print $0; }'
 				)"
@@ -1565,7 +1560,7 @@ function test_custom_ssh_configuration ()
 
 			it "Logs a redacted value."
 				user_password="$(
-					__docker_logs_match \
+					docker logs \
 						ssh.1 \
 					| awk '/^password :.*$/ { print $0; }'
 				)"
@@ -1634,7 +1629,7 @@ function test_custom_ssh_configuration ()
 
 			it "Logs a redacted value."
 				user_password="$(
-					__docker_logs_match \
+					docker logs \
 						ssh.1 \
 					| awk '/^password :.*$/ { print $0; }'
 				)"
@@ -1684,7 +1679,7 @@ function test_custom_ssh_configuration ()
 
 			it "Logs the setting value."
 				timezone="$(
-					__docker_logs_match \
+					docker logs \
 						ssh.1 \
 					| awk '/^timezone :.*$/ { print $0; }'
 				)"
@@ -1711,7 +1706,7 @@ function test_custom_ssh_configuration ()
 			sleep ${STARTUP_TIME}
 
 			it "Can disable sshd-bootstrap."
-				__docker_logs_match \
+				docker logs \
 					ssh.1 \
 				| grep -qE 'INFO success: sshd-bootstrap entered RUNNING state'
 
@@ -1843,7 +1838,7 @@ function test_custom_sftp_configuration ()
 
 			it "Logs the setting value."
 				password_authentication="$(
-					__docker_logs_match \
+					docker logs \
 						sftp.1 \
 					| awk '/^password authentication :.*$/ { print $0; }'
 				)"
@@ -1907,7 +1902,7 @@ function test_custom_sftp_configuration ()
 
 			it "Logs the setting value."
 				chroot_path="$(
-					__docker_logs_match \
+					docker logs \
 						sftp.1 \
 					| awk '/^chroot path :.*$/ { print $0; }'
 				)"

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -1698,16 +1698,7 @@ function test_custom_ssh_configuration ()
 				jdeathe/centos-ssh:latest \
 			&> /dev/null
 
-			if ! __is_container_ready \
-				ssh.1 \
-				${STARTUP_TIME} \
-				"/usr/sbin/sshd " \
-				"grep \
-					'^Server listening on 0\.0\.0\.0 port 22\.' \
-					/var/log/secure"
-			then
-				exit 1
-			fi
+			sleep ${STARTUP_TIME}
 
 			it "Can disable sshd-bootstrap."
 				docker logs \

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -27,11 +27,6 @@ function __docker_logs_match ()
 	local counter="${3:-${STARTUP_TIME}}"
 	local value=""
 
-	if [[ -z ${container} ]]
-	then
-		return 1
-	fi
-
 	until (( counter == 0 ))
 	do
 		sleep 1

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -22,17 +22,23 @@ function __destroy ()
 
 function __docker_logs_match ()
 {
-	local -r pattern="${2:-'INFO exited: *expected'}"
+	local -r container="${1:-}"
+	local -r pattern="${2:-"INFO exited: .*expected"}"
 
 	local counter="${3:-${STARTUP_TIME}}"
-	local value=""
+	local value
+
+	if [[ -z ${container} ]]
+	then
+		return 1
+	fi
 
 	until (( counter == 0 ))
 	do
 		sleep 1
 
 		value="$(
-			docker logs ${1:-}
+			docker logs "${container}"
 		)"
 
 		if [[ ${value} =~ ${pattern} ]]
@@ -980,7 +986,7 @@ function test_custom_ssh_configuration ()
 
 				it "Logs the key signature."
 					user_key_signature="$(
-						docker logs \
+						__docker_logs_match \
 							ssh.1 \
 						| sed -n -e '/^rsa private key fingerprint :$/{ n; p; }' \
 						| awk '{ print $1; }'
@@ -1039,7 +1045,7 @@ function test_custom_ssh_configuration ()
 
 				it "Logs the key signature."
 					user_key_signature="$(
-						docker logs \
+						__docker_logs_match \
 							ssh.1 \
 						| sed -n -e '/^rsa private key fingerprint :$/{ n; p; }' \
 						| awk '{ print $1; }'

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -2080,6 +2080,7 @@ function test_custom_sftp_configuration ()
 
 function test_healthcheck ()
 {
+	local -r event_lag_seconds=2
 	local -r interval_seconds=0.5
 	local -r retries=5
 	local health_status=""
@@ -2115,9 +2116,10 @@ function test_healthcheck ()
 
 			sleep $(
 				awk \
-					-v interval_seconds="${interval_seconds}" \
+					-v event_lag="${event_lag_seconds}" \
+					-v interval="${interval_seconds}" \
 					-v startup_time="${STARTUP_TIME}" \
-					'BEGIN { print 1 + interval_seconds + startup_time; }'
+					'BEGIN { print startup_time + interval; }'
 			)
 
 			it "Returns healthy after startup."
@@ -2147,9 +2149,10 @@ function test_healthcheck ()
 
 				sleep $(
 					awk \
-						-v interval_seconds="${interval_seconds}" \
+						-v event_lag="${event_lag_seconds}" \
+						-v interval="${interval_seconds}" \
 						-v retries="${retries}" \
-						'BEGIN { print 1 + interval_seconds * retries; }'
+						'BEGIN { print event_lag + (interval * retries); }'
 				)
 
 				health_status="$(
@@ -2190,9 +2193,10 @@ function test_healthcheck ()
 
 			sleep $(
 				awk \
-					-v interval_seconds="${interval_seconds}" \
+					-v event_lag="${event_lag_seconds}" \
+					-v interval="${interval_seconds}" \
 					-v startup_time="${STARTUP_TIME}" \
-					'BEGIN { print 1 + interval_seconds + startup_time; }'
+					'BEGIN { print startup_time + interval; }'
 			)
 
 			it "Returns healthy after startup."
@@ -2217,9 +2221,10 @@ function test_healthcheck ()
 
 				sleep $(
 					awk \
-						-v interval_seconds="${interval_seconds}" \
+						-v event_lag="${event_lag_seconds}" \
+						-v interval="${interval_seconds}" \
 						-v retries="${retries}" \
-						'BEGIN { print 1 + interval_seconds * retries; }'
+						'BEGIN { print event_lag + (interval * retries); }'
 				)
 
 				health_status="$(

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -2087,7 +2087,7 @@ function test_custom_sftp_configuration ()
 function test_healthcheck ()
 {
 	local -r event_lag_seconds=2
-	local -r interval_seconds=0.5
+	local -r interval_seconds=1
 	local -r retries=5
 	local health_status=""
 
@@ -2125,7 +2125,7 @@ function test_healthcheck ()
 					-v event_lag="${event_lag_seconds}" \
 					-v interval="${interval_seconds}" \
 					-v startup_time="${STARTUP_TIME}" \
-					'BEGIN { print event_lag + startup_time + interval; }'
+					'BEGIN { print startup_time + interval; }'
 			)
 
 			it "Returns healthy after startup."
@@ -2202,7 +2202,7 @@ function test_healthcheck ()
 					-v event_lag="${event_lag_seconds}" \
 					-v interval="${interval_seconds}" \
 					-v startup_time="${STARTUP_TIME}" \
-					'BEGIN { print event_lag + startup_time + interval; }'
+					'BEGIN { print startup_time + interval; }'
 			)
 
 			it "Returns healthy after startup."

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -2125,7 +2125,7 @@ function test_healthcheck ()
 					-v event_lag="${event_lag_seconds}" \
 					-v interval="${interval_seconds}" \
 					-v startup_time="${STARTUP_TIME}" \
-					'BEGIN { print startup_time + interval; }'
+					'BEGIN { print event_lag + startup_time + interval; }'
 			)
 
 			it "Returns healthy after startup."
@@ -2202,7 +2202,7 @@ function test_healthcheck ()
 					-v event_lag="${event_lag_seconds}" \
 					-v interval="${interval_seconds}" \
 					-v startup_time="${STARTUP_TIME}" \
-					'BEGIN { print startup_time + interval; }'
+					'BEGIN { print event_lag + startup_time + interval; }'
 			)
 
 			it "Returns healthy after startup."


### PR DESCRIPTION
CLOSES #662

- Updates default HEALTHCHECK interval to 1 second from 0.5.
- Adds consideration for event lag into test cases for unhealthy health_status events.