### PR TITLE
CLOSES #678: Fixes issue with missing Details docker logs output.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Summary of release changes for Version 1 - CentOS-6
 - Adds `SSH_USER_PRIVATE_KEY` to allow configuration of an RSA private key for `SSH_USER`.
 - Adds placeholder replacement of `RELEASE_VERSION` docker argument to systemd service unit template.
 - Adds error messages to healthcheck script and includes supervisord check.
-- Adds `__docker_logs_match` function to test cases to work-around output delays on CI service's host.
+- Adds a short sleep after bootstrap Details to work-around missing output on CI service's host.
 - Adds port incrementation to Makefile's run template for container names with an instance suffix.
 - Adds consideration for event lag into test cases for unhealthy health_status events.
 - Removes use of `/etc/services-config` paths.

--- a/src/usr/sbin/sshd-bootstrap
+++ b/src/usr/sbin/sshd-bootstrap
@@ -328,6 +328,7 @@ function get_ssh_host_key_fingerprint ()
 				printf -- \
 					'ERROR: invalid host key\n' \
 					>&2
+				sleep 0.1
 
 				return 1
 			fi
@@ -336,6 +337,7 @@ function get_ssh_host_key_fingerprint ()
 			printf -- \
 				'ERROR: invalid key type\n' \
 				>&2
+			sleep 0.1
 
 			return 1
 			;;
@@ -609,6 +611,7 @@ function generate_ssh_host_keys ()
 		printf -- \
 			"ERROR: Unknown EL release.\n" \
 			>&2
+		sleep 0.1
 
 		return 1
 	fi
@@ -1090,6 +1093,9 @@ then
 		${TIMER_TOTAL}
 
 	EOT
+
+	# Attempt to force output flush
+	sleep 0.1
 fi
 
 # Release lock file

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -20,34 +20,6 @@ function __destroy ()
 	:
 }
 
-function __docker_logs_match ()
-{
-	local -r pattern="${2:-'INFO exited: .*expected'}"
-
-	local counter="${3:-${STARTUP_TIME}}"
-	local value=""
-
-	until (( counter == 0 ))
-	do
-		sleep 1
-
-		value="$(
-			docker logs ${1:-}
-		)"
-
-		if [[ ${value} =~ ${pattern} ]]
-		then
-			break
-		fi
-
-		(( counter -= 1 ))
-	done
-
-	printf -- \
-		'%s' \
-		"${value}"
-}
-
 function __get_container_port ()
 {
 	local container="${1:-}"
@@ -464,7 +436,7 @@ function test_custom_ssh_configuration ()
 
 			it "Can connect using password authentication."
 				password="$(
-					__docker_logs_match \
+					docker logs \
 						ssh.1 \
 					| awk '/^password :.*$/ { print $3; }'
 				)"
@@ -736,7 +708,7 @@ function test_custom_ssh_configuration ()
 
 			it "Logs the key signature."
 				user_key_signature="$(
-					__docker_logs_match \
+					docker logs \
 						ssh.1 \
 					| awk '/^45:46:b0:ef:a5:e3:c9:6f:1e:66:94:ba:e1:fd:df:65$/ { print $1; }'
 				)"
@@ -1792,7 +1764,7 @@ function test_custom_sftp_configuration ()
 
 			it "Can connect using password authentication."
 				password="$(
-					__docker_logs_match \
+					docker logs \
 						sftp.1 \
 					| awk '/^password :.*$/ { print $3; }'
 				)"
@@ -1972,7 +1944,7 @@ function test_custom_sftp_configuration ()
 
 				it "Logs N/A key signature."
 					user_key_signature="$(
-						__docker_logs_match \
+						docker logs \
 							sftp.1 \
 						| sed -n -e '/^rsa private key fingerprint :$/{ n; p; }' \
 						| awk '{ print $1; }'


### PR DESCRIPTION
CLOSES #678: Patches back #677.

- Adds a short sleep after bootstrap Details to work-around missing output on CI service's host.