### PR TITLE
CLOSES #690: Fixes validation logic for SSH_TIMEZONE.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Summary of release changes for Version 1 - CentOS-6
 - Fixes issue with redacted password when using `SSH_PASSWORD_AUTHENTICATION` in combination with `SSH_USER_FORCE_SFTP`.
 - Fixes issue with unexpected published port in run templates when `DOCKER_PORT_MAP_TCP_22` is set to an empty string or 0.
 - Fixes missing `SSH_TIMEZONE` from Makefile's install run template.
+- Fixes validation of `SSH_TIMEZONE` values - set to defaults with warning and abort on error.
 - Adds `SSH_USER_PRIVATE_KEY` to allow configuration of an RSA private key for `SSH_USER`.
 - Adds placeholder replacement of `RELEASE_VERSION` docker argument to systemd service unit template.
 - Adds error messages to healthcheck script and includes supervisord check.

--- a/src/usr/sbin/sshd-bootstrap
+++ b/src/usr/sbin/sshd-bootstrap
@@ -58,19 +58,6 @@ function is_valid_ssh_authorized_keys ()
 	return 0
 }
 
-function is_valid_ssh_password_authentication ()
-{
-	local -r boolean_value='^(true|false)$'
-	local -r value="${1}"
-
-	if [[ ${value} =~ ${boolean_value} ]]
-	then
-		return 0
-	fi
-
-	return 1
-}
-
 function is_valid_ssh_chroot_directory ()
 {
 	local -r chroot_directory="${1:-}"
@@ -103,6 +90,19 @@ function is_valid_ssh_key ()
 	fi
 
 	return 0
+}
+
+function is_valid_ssh_password_authentication ()
+{
+	local -r boolean_value='^(true|false)$'
+	local -r value="${1}"
+
+	if [[ ${value} =~ ${boolean_value} ]]
+	then
+		return 0
+	fi
+
+	return 1
 }
 
 function is_valid_ssh_timezone ()
@@ -172,6 +172,30 @@ function is_valid_ssh_user_home ()
 	return 1
 }
 
+function is_valid_ssh_user_id ()
+{
+	local -r id="${1}"
+	local -r user_id_pattern='^[1-9][0-9]*:[1-9][0-9]*$'
+	local -r root_id_pattern='^0:0$'
+	local -r user="${2:-"$(
+		get_ssh_user
+	)"}"
+
+	local id_pattern="${user_id_pattern}"
+
+	if [[ ${user} == root ]]
+	then
+		id_pattern="${root_id_pattern}"
+	fi
+
+	if [[ ${id} =~ ${id_pattern} ]]
+	then
+		return 0
+	fi
+
+	return 1
+}
+
 function is_valid_ssh_user_password_hash ()
 {
 	local -r password_hash="${1}"
@@ -223,30 +247,6 @@ function is_valid_ssh_user_shell ()
 	return 1
 }
 
-function is_valid_ssh_user_id ()
-{
-	local -r id="${1}"
-	local -r user_id_pattern='^[1-9][0-9]*:[1-9][0-9]*$'
-	local -r root_id_pattern='^0:0$'
-	local -r user="${2:-"$(
-		get_ssh_user
-	)"}"
-
-	local id_pattern="${user_id_pattern}"
-
-	if [[ ${user} == root ]]
-	then
-		id_pattern="${root_id_pattern}"
-	fi
-
-	if [[ ${id} =~ ${id_pattern} ]]
-	then
-		return 0
-	fi
-
-	return 1
-}
-
 function get_password ()
 {
 	local -r password_length="${1:-16}"
@@ -286,21 +286,6 @@ function get_ssh_authorized_keys ()
 	# the original behaviour.
 	if [[ ${password_authentication} == false ]] \
 		&& [[ -z ${value} ]]
-	then
-		value="${default_value}"
-	fi
-
-	printf -- '%s' "${value}"
-}
-
-function get_ssh_password_authentication ()
-{
-	local -r default_value="${1:-false}"
-
-	local value="${SSH_PASSWORD_AUTHENTICATION:-}"
-
-	if [[ -z ${value} ]] \
-		|| ! is_valid_ssh_password_authentication "${value}"
 	then
 		value="${default_value}"
 	fi
@@ -494,6 +479,51 @@ function get_ssh_key_fingerprint_hash_output ()
 	printf -- '%s' "${value}"
 }
 
+function get_ssh_password_authentication ()
+{
+	local -r default_value="${1:-false}"
+
+	local value="${SSH_PASSWORD_AUTHENTICATION:-}"
+
+	if [[ -z ${value} ]] \
+		|| ! is_valid_ssh_password_authentication "${value}"
+	then
+		value="${default_value}"
+	fi
+
+	printf -- '%s' "${value}"
+}
+
+function get_ssh_timezone ()
+{
+	local -r default_value="${1:-UTC}"
+
+	local value="${SSH_TIMEZONE:-}"
+
+	if [[ -z ${value} ]] \
+		|| ! is_valid_ssh_timezone "${value}"
+	then
+		value="${default_value}"
+	fi
+
+	printf -- '%s' "${value}"
+}
+
+function get_ssh_user ()
+{
+	local -r default_value="${1:-app-admin}"
+
+	local value="${SSH_USER:-}"
+
+	if [[ -z ${value} ]] \
+		|| ! is_valid_ssh_user "${value}"
+	then
+		value="${default_value}"
+	fi
+
+	printf -- '%s' "${value}"
+}
+
 function get_ssh_user_password_hashed ()
 {
 	local -r default_value="${1:-false}"
@@ -531,21 +561,6 @@ function get_ssh_user_private_key ()
 	printf -- '%s' "${value}"
 }
 
-function get_ssh_user ()
-{
-	local -r default_value="${1:-app-admin}"
-
-	local value="${SSH_USER:-}"
-
-	if [[ -z ${value} ]] \
-		|| ! is_valid_ssh_user "${value}"
-	then
-		value="${default_value}"
-	fi
-
-	printf -- '%s' "${value}"
-}
-
 function get_ssh_user_force_sftp ()
 {
 	local -r default_value="${1:-false}"
@@ -559,6 +574,24 @@ function get_ssh_user_force_sftp ()
 	fi
 
 	printf -- '%s' "${value}"
+}
+
+function get_ssh_user_gid ()
+{
+	local -r default_value="${1:-500}"
+	local -r id="$(
+		get_ssh_user_id
+	)"
+	local -r id_pattern='^([0-9]{1,}):([0-9]{1,})$'
+
+	local value="${default_value}"
+
+	if [[ ${id} =~ ${id_pattern} ]]
+	then
+		value="${BASH_REMATCH[2]}"
+	fi
+
+	printf -- '%d' "${value}"
 }
 
 function get_ssh_user_home ()
@@ -584,6 +617,30 @@ function get_ssh_user_home ()
 
 	# Replace %u with SSH_USER
 	value="${value//'%u'/${user}}"
+
+	printf -- '%s' "${value}"
+}
+
+function get_ssh_user_id ()
+{
+	local -r default_value="${1:-500:500}"
+	local -r root_value="0:0"
+	local -r user="${2:-"$(
+		get_ssh_user
+	)"}"
+
+	local value="${SSH_USER_ID:-}"
+
+	if [[ -z ${value} ]] \
+		|| ! is_valid_ssh_user_id "${value}"
+	then
+		if [[ ${user} == root ]]
+		then
+			value="${root_value}"
+		else
+			value="${default_value}"
+		fi
+	fi
 
 	printf -- '%s' "${value}"
 }
@@ -625,48 +682,6 @@ function get_ssh_user_uid ()
 	if [[ ${id} =~ ${id_pattern} ]]
 	then
 		value="${BASH_REMATCH[1]}"
-	fi
-
-	printf -- '%d' "${value}"
-}
-
-function get_ssh_user_id ()
-{
-	local -r default_value="${1:-500:500}"
-	local -r root_value="0:0"
-	local -r user="${2:-"$(
-		get_ssh_user
-	)"}"
-
-	local value="${SSH_USER_ID:-}"
-
-	if [[ -z ${value} ]] \
-		|| ! is_valid_ssh_user_id "${value}"
-	then
-		if [[ ${user} == root ]]
-		then
-			value="${root_value}"
-		else
-			value="${default_value}"
-		fi
-	fi
-
-	printf -- '%s' "${value}"
-}
-
-function get_ssh_user_gid ()
-{
-	local -r default_value="${1:-500}"
-	local -r id="$(
-		get_ssh_user_id
-	)"
-	local -r id_pattern='^([0-9]{1,}):([0-9]{1,})$'
-
-	local value="${default_value}"
-
-	if [[ ${id} =~ ${id_pattern} ]]
-	then
-		value="${BASH_REMATCH[2]}"
 	fi
 
 	printf -- '%d' "${value}"
@@ -880,6 +895,7 @@ then
 	declare -A ENV_VALIDATION_WITH_DEFAULTS=(
 		[SSH_CHROOT_DIRECTORY]=is_valid_ssh_chroot_directory
 		[SSH_PASSWORD_AUTHENTICATION]=is_valid_ssh_password_authentication
+		[SSH_TIMEZONE]=is_valid_ssh_timezone
 		[SSH_USER]=is_valid_ssh_user
 		[SSH_USER_FORCE_SFTP]=is_valid_ssh_user_force_sftp
 		[SSH_USER_HOME]=is_valid_ssh_user_home
@@ -894,7 +910,9 @@ then
 		get_ssh_password_authentication
 	)"
 	OPTS_SSH_SUDO="${SSH_SUDO:-${DEFAULT_SSH_SUDO}}"
-	OPTS_SSH_TIMEZONE="${SSH_TIMEZONE:-UTC}"
+	OPTS_SSH_TIMEZONE="$(
+		get_ssh_timezone
+	)"
 	OPTS_SSH_USER="$(
 		get_ssh_user
 	)"
@@ -970,7 +988,15 @@ then
 		fi
 	done
 
-	set_ssh_timezone "${OPTS_SSH_TIMEZONE}"
+	if ! set_ssh_timezone "${OPTS_SSH_TIMEZONE}"
+	then
+		printf -- \
+			'ERROR: Could not set timezone - aborting.\n' \
+			>&2
+		sleep 0.1
+
+		exit 1
+	fi
 
 	$(
 		generate_ssh_host_keys


### PR DESCRIPTION
CLOSES #690: Patches back #689.

- Fixes validation of `SSH_TIMEZONE` values - set to defaults with warning and abort on error.