### PR TITLE
CLOSES #721: Adds /bin to the search paths for prerequistes of scmi installer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Summary of release changes for Version 2 - CentOS-7
 
+### 2.5.1 - Unreleased
+
+- Fixes `scmi` installation error when using the `--manager=systemd` option on Ubuntu hosts.
+
 ### 2.5.0 - 2019-01-28
 
 - Updates `openssl` package to 1.0.2k-16.el7.

--- a/src/usr/sbin/scmi
+++ b/src/usr/sbin/scmi
@@ -990,6 +990,7 @@ function scmi_manager_type_command_prerequisites ()
 	local -a COMMAND_PATHS=(
 		'/usr/local/bin'
 		'/usr/bin'
+		'/bin'
 	)
 	local MANAGER_TYPE="${1:-${SCMI_MANAGER_TYPE}}"
 


### PR DESCRIPTION
CLOSES #721 

- Fixes `scmi` installation error when using the `--manager=systemd` option on Ubuntu hosts.