### PR TITLE
CLOSES #722: Adds /bin to the search paths for prerequistes of scmi installer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Summary of release changes for Version 1 - CentOS-6
 
+### 1.10.1 - Unreleased
+
+- Fixes `scmi` installation error when using the `--manager=systemd` option on Ubuntu hosts.
+
 ### 1.10.0 - 2019-01-28
 
 - Updates supervisor to 3.3.5.

--- a/src/usr/sbin/scmi
+++ b/src/usr/sbin/scmi
@@ -990,6 +990,7 @@ function scmi_manager_type_command_prerequisites ()
 	local -a COMMAND_PATHS=(
 		'/usr/local/bin'
 		'/usr/bin'
+		'/bin'
 	)
 	local MANAGER_TYPE="${1:-${SCMI_MANAGER_TYPE}}"
 


### PR DESCRIPTION
CLOSES #722: Patches back #721.

- Fixes `scmi` installation error when using the `--manager=systemd` option on Ubuntu hosts.