### PR TITLE
CLOSES #724: Fixes issues with scmi systemd install/uninstall failures.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Summary of release changes for Version 1 - CentOS-6
 ### 1.10.1 - Unreleased
 
 - Fixes `scmi` installation error when using the `--manager=systemd` option on Ubuntu hosts.
+- Fixes issues with failure to install/uninstall systemd units installed with scmi.
 
 ### 1.10.0 - 2019-01-28
 

--- a/src/etc/systemd/system/centos-ssh@.service
+++ b/src/etc/systemd/system/centos-ssh@.service
@@ -35,6 +35,7 @@
 #
 # To uninstall:
 #     sudo systemctl disable -f {service-unit-instance-name}
+#     sudo systemctl daemon-reload
 #     sudo systemctl stop {service-unit-instance-name}
 #     sudo rm /etc/systemd/system/{service-unit-template-name}
 #     sudo docker rm -f {service-unit-long-name}
@@ -155,10 +156,10 @@ ExecStart=/bin/bash -c \
     then \
       if /usr/bin/grep -qE \
           '^([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}:)?[1-9][0-9]*$' \
-          <<< \"${DOCKER_PORT_MAP_TCP_22}\"; \
+          <<< \"${DOCKER_PORT_MAP_TCP_22}\" \
         && /usr/bin/grep -qE \
           '^.+\.[0-9]+(\.[0-9]+)?$' \
-          <<< "${DOCKER_NAME}"
+          <<< \"${DOCKER_NAME}\"; \
       then \
         printf -- '--publish %%s%%s:22' \
           $(\

--- a/src/usr/sbin/scmi
+++ b/src/usr/sbin/scmi
@@ -1701,6 +1701,7 @@ function scmi_systemd_uninstall ()
 	then
 		scmi_print_message "sub_step_info" \
 			"Stopping ${SERVICE_UNIT_INSTANCE_NAME}"
+		${systemctl} daemon-reload
 		scmi_run_step \
 			"${systemctl} stop ${SERVICE_UNIT_INSTANCE_NAME}"
 	fi


### PR DESCRIPTION
CLOSES #724: Patches back #723.

- Fixes issues with failure to install/uninstall systemd units installed with scmi.