### PR TITLE
CLOSES #720: Patch back #719.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 .gitignore
 dist
 test
+docker-compose.yml
 LICENSE
 README-short.txt
 *.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Summary of release changes for Version 1 - CentOS-6
 - Fixes `scmi` installation error when using the `--manager=systemd` option on Ubuntu hosts.
 - Fixes issues with failure to install/uninstall systemd units installed with scmi.
 - Adds improvement to pull logic in systemd unit install template.
-- Adds `docker-comose.yml` to `.dockerignore` to reduce size of build context.
+- Adds `docker-compose.yml` to `.dockerignore` to reduce size of build context.
 - Removes reference to `python-setuptools` from README as it's no longer installed.
 
 ### 1.10.0 - 2019-01-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Summary of release changes for Version 1 - CentOS-6
 - Fixes `scmi` installation error when using the `--manager=systemd` option on Ubuntu hosts.
 - Fixes issues with failure to install/uninstall systemd units installed with scmi.
 - Adds improvement to pull logic in systemd unit install template.
+- Adds `docker-comose.yml` to `.dockerignore` to reduce size of build context.
 - Removes reference to `python-setuptools` from README as it's no longer installed.
 
 ### 1.10.0 - 2019-01-28


### PR DESCRIPTION
CLOSES #720: Patch back #719.

- Adds `docker-compose.yml` to `.dockerignore` to reduce size of build context.