### PR TITLE
CLOSES #749: Fixes port incrementation for scmi systemd installations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Summary of release changes for Version 2 - CentOS-7
 
+### 2.5.2 - Unreleased
+
+- Fixes issue with port incrementation failure when installing systemd units via `scmi`.
+
 ### 2.5.1 - 2019-02-28
 
 - Deprecates use of `supervisor_stdout` - the default value of `SSH_AUTOSTART_SUPERVISOR_STDOUT` will be switched to "false" in a future release.

--- a/src/etc/systemd/system/centos-ssh@.service
+++ b/src/etc/systemd/system/centos-ssh@.service
@@ -153,7 +153,7 @@ ExecStart=/bin/bash -c \
           <<< \"${DOCKER_PORT_MAP_TCP_22}\" \
         && /usr/bin/grep -qE \
           '^.+\.[0-9]+(\.[0-9]+)?$' \
-          <<< \"${DOCKER_NAME}\"; \
+          <<< %p.%i; \
       then \
         printf -- '--publish %%s%%s:22' \
           $(\


### PR DESCRIPTION
CLOSES #749

- Fixes issue with port incrementation failure when installing systemd units via `scmi`.