### PR TITLE
CLOSES #754: Fixes binary paths in systemd unit files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ Summary of release changes for Version 1 - CentOS-6
 
 ### 1.10.2 - Unreleased
 
-- Fixes issue with port incrementation failure when installing systemd units via `scmi`.
+- Fixes port incrementation failures when installing systemd units via `scmi`.
+- Fixes etcd port registration failures when installing systemd units via `scmi` with the `--register` option.
+- Fixes binary paths in systemd unit files for compatibility with both EL and Ubuntu hosts.
 
 ### 1.10.1 - 2019-02-28
 

--- a/src/etc/systemd/system/centos-ssh.register@.service
+++ b/src/etc/systemd/system/centos-ssh.register@.service
@@ -86,7 +86,7 @@ ExecStart=/bin/bash -c \
         \"$(/usr/bin/docker port \
             {{SERVICE_UNIT_NAME}}.%i \
             22 \
-          | /usr/bin/sed 's~^[0-9.]*:~~' \
+          | /bin/sed 's~^[0-9.]*:~~' \
         )\" \
         --ttl ${REGISTER_TTL} 2> /dev/null; \
     fi; \
@@ -111,15 +111,15 @@ ExecStart=/bin/bash -c \
             ${REGISTER_KEY_ROOT}/ports/tcp/22 \
           &> /dev/null; \
         then \
-          echo set; \
+          /usr/bin/printf -- 'set\n'; \
         else \
-          echo update; \
+          /usr/bin/printf -- 'update\n'; \
         fi) \
         ${REGISTER_KEY_ROOT}/ports/tcp/22 \
         \"$(/usr/bin/docker port \
             {{SERVICE_UNIT_NAME}}.%i \
             22 \
-          | /usr/bin/sed 's~^[0-9.]*:~~' \
+          | /bin/sed 's~^[0-9.]*:~~' \
         )\" \
         --ttl ${REGISTER_TTL}; \
     fi; \
@@ -131,9 +131,9 @@ ExecStart=/bin/bash -c \
           ${REGISTER_KEY_ROOT}/hostname \
         &> /dev/null; \
       then \
-        echo set; \
+        /usr/bin/printf -- 'set\n'; \
       else \
-        echo update; \
+        /usr/bin/printf -- 'update\n'; \
       fi) \
       ${REGISTER_KEY_ROOT}/hostname \
       %H \

--- a/src/etc/systemd/system/centos-ssh@.service
+++ b/src/etc/systemd/system/centos-ssh@.service
@@ -85,7 +85,7 @@ ExecStartPre=/bin/bash -c \
   then \
     if [[ -f ${DOCKER_IMAGE_PACKAGE_PATH}/${DOCKER_USER}/${DOCKER_IMAGE_NAME}.${DOCKER_IMAGE_TAG}.tar.xz ]]; \
     then \
-      printf -- '%%s/%%s/%%s.%%s.tar.xz\n' \
+      /usr/bin/printf -- '%%s/%%s/%%s.%%s.tar.xz\n' \
         \"${DOCKER_IMAGE_PACKAGE_PATH}\" \
         \"${DOCKER_USER}\" \
         \"${DOCKER_IMAGE_NAME}\" \
@@ -93,7 +93,7 @@ ExecStartPre=/bin/bash -c \
       | /usr/bin/xargs /usr/bin/xz -dc \
       | /usr/bin/docker load; \
     else \
-      printf -- '%%s/%%s:%%s\n' \
+      /usr/bin/printf -- '%%s/%%s:%%s\n' \
         \"${DOCKER_USER}\" \
         \"${DOCKER_IMAGE_NAME}\" \
         \"${DOCKER_IMAGE_TAG}\" \
@@ -148,37 +148,37 @@ ExecStart=/bin/bash -c \
     --env \"SSH_USER_SHELL=${SSH_USER_SHELL}\" \
     $(if [[ ${DOCKER_PORT_MAP_TCP_22} != NULL ]]; \
     then \
-      if /usr/bin/grep -qE \
+      if /bin/grep -qE \
           '^([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}:)?[1-9][0-9]*$' \
           <<< \"${DOCKER_PORT_MAP_TCP_22}\" \
-        && /usr/bin/grep -qE \
+        && /bin/grep -qE \
           '^.+\.[0-9]+(\.[0-9]+)?$' \
           <<< %p.%i; \
       then \
-        printf -- '--publish %%s%%s:22' \
+        /usr/bin/printf -- '--publish %%s%%s:22' \
           $(\
-            /usr/bin/grep -o \
+            /bin/grep -o \
               '^[0-9\.]*:' \
               <<< \"${DOCKER_PORT_MAP_TCP_22}\" \
           ) \
           $(( \
             $(\
-              /usr/bin/grep -oE \
+              /bin/grep -oE \
                 '[0-9]+$' \
                 <<< \"${DOCKER_PORT_MAP_TCP_22}\" \
             ) \
             + $(\
-              /usr/bin/grep -oE \
+              /bin/grep -oE \
                 '^[0-9]+' \
                 <<< %i \
             ) \
             - 1 \
           )); \
       else \
-        printf -- '--publish %%s:22' \
+        /usr/bin/printf -- '--publish %%s:22' \
           \"${DOCKER_PORT_MAP_TCP_22}\"; \
       fi; \
-    fi) \
+    fi;) \
     ${DOCKER_CONTAINER_OPTS} \
     ${DOCKER_USER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}; \
   "

--- a/src/etc/systemd/system/centos-ssh@.service
+++ b/src/etc/systemd/system/centos-ssh@.service
@@ -178,7 +178,7 @@ ExecStart=/bin/bash -c \
         /usr/bin/printf -- '--publish %%s:22' \
           \"${DOCKER_PORT_MAP_TCP_22}\"; \
       fi; \
-    fi;) \
+    fi) \
     ${DOCKER_CONTAINER_OPTS} \
     ${DOCKER_USER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}; \
   "


### PR DESCRIPTION
CLOSES #754: Patches back #753.

- Fixes etcd port registration failures when installing systemd units via `scmi` with the `--register` option.
- Fixes binary paths in systemd unit files for compatibility with both EL and Ubuntu hosts.