### PR TITLE
CLOSES #758: Updates source tag to CentOS 7.6.1810.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 Summary of release changes for Version 2 - CentOS-7
 
-### 2.5.2 - Unreleased
+### 2.6.0 - Unreleased
 
+- Updates source tag to CentOS 7.6.1810.
 - Fixes port incrementation failures when installing systemd units via `scmi`.
 - Fixes etcd port registration failures when installing systemd units via `scmi` with the `--register` option.
 - Fixes binary paths in systemd unit files for compatibility with both EL and Ubuntu hosts.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7.5.1804
+FROM centos:7.6.1810
 
 ARG RELEASE_VERSION="2.5.1"
 
@@ -140,7 +140,7 @@ jdeathe/centos-ssh:${RELEASE_VERSION} \
 	org.deathe.license="MIT" \
 	org.deathe.vendor="jdeathe" \
 	org.deathe.url="https://github.com/jdeathe/centos-ssh" \
-	org.deathe.description="CentOS-7 7.5.1804 x86_64 - SCL, EPEL and IUS Repositories / Supervisor / OpenSSH."
+	org.deathe.description="CentOS-7 7.6.1810 x86_64 - SCL, EPEL and IUS Repositories / Supervisor / OpenSSH."
 
 HEALTHCHECK \
 	--interval=1s \

--- a/README-short.txt
+++ b/README-short.txt
@@ -1,1 +1,1 @@
-CentOS-6 6.10 x86_64 / CentOS-7 7.5.1804 x86_64 - SCL/EPEL/IUS Repos / Supervisor / OpenSSH.
+CentOS-6 6.10 x86_64 / CentOS-7 7.6.1810 x86_64 - SCL/EPEL/IUS Repos / Supervisor / OpenSSH.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 centos-ssh
 ==========
 
-Docker Images of CentOS-6 6.10 x86_64 / CentOS-7 7.5.1804 x86_64
+Docker Images of CentOS-6 6.10 x86_64 / CentOS-7 7.6.1810 x86_64
 
 Includes public key authentication, Automated password generation and supports custom configuration via environment variables.
 


### PR DESCRIPTION
CLOSES #758

- Updates source tag to CentOS 7.6.1810.