### PR TITLE
CLOSES #762: Use bash builtin version of printf in systemd unit files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Summary of release changes for Version 2 - CentOS-7
 - Fixes port incrementation failures when installing systemd units via `scmi`.
 - Fixes etcd port registration failures when installing systemd units via `scmi` with the `--register` option.
 - Fixes binary paths in systemd unit files for compatibility with both EL and Ubuntu hosts.
+- Fixes use of printf binary instead of builtin in systemd unit files.
 
 ### 2.5.1 - 2019-02-28
 

--- a/src/etc/systemd/system/centos-ssh.register@.service
+++ b/src/etc/systemd/system/centos-ssh.register@.service
@@ -35,6 +35,7 @@
 #
 # To uninstall:
 #     sudo systemctl disable -f {service-unit-instance-name}
+#     sudo systemctl daemon-reload
 #     sudo rm /etc/systemd/system/{service-unit-template-name}
 #     sudo systemctl daemon-reload
 # ------------------------------------------------------------------------------
@@ -111,9 +112,9 @@ ExecStart=/bin/bash -c \
             ${REGISTER_KEY_ROOT}/ports/tcp/22 \
           &> /dev/null; \
         then \
-          /usr/bin/printf -- 'set\n'; \
+          printf -- 'set\n'; \
         else \
-          /usr/bin/printf -- 'update\n'; \
+          printf -- 'update\n'; \
         fi) \
         ${REGISTER_KEY_ROOT}/ports/tcp/22 \
         \"$(/usr/bin/docker port \
@@ -131,9 +132,9 @@ ExecStart=/bin/bash -c \
           ${REGISTER_KEY_ROOT}/hostname \
         &> /dev/null; \
       then \
-        /usr/bin/printf -- 'set\n'; \
+        printf -- 'set\n'; \
       else \
-        /usr/bin/printf -- 'update\n'; \
+        printf -- 'update\n'; \
       fi) \
       ${REGISTER_KEY_ROOT}/hostname \
       %H \

--- a/src/etc/systemd/system/centos-ssh@.service
+++ b/src/etc/systemd/system/centos-ssh@.service
@@ -85,7 +85,7 @@ ExecStartPre=/bin/bash -c \
   then \
     if [[ -f ${DOCKER_IMAGE_PACKAGE_PATH}/${DOCKER_USER}/${DOCKER_IMAGE_NAME}.${DOCKER_IMAGE_TAG}.tar.xz ]]; \
     then \
-      /usr/bin/printf -- '%%s/%%s/%%s.%%s.tar.xz\n' \
+      printf -- '%%s/%%s/%%s.%%s.tar.xz\n' \
         \"${DOCKER_IMAGE_PACKAGE_PATH}\" \
         \"${DOCKER_USER}\" \
         \"${DOCKER_IMAGE_NAME}\" \
@@ -93,7 +93,7 @@ ExecStartPre=/bin/bash -c \
       | /usr/bin/xargs /usr/bin/xz -dc \
       | /usr/bin/docker load; \
     else \
-      /usr/bin/printf -- '%%s/%%s:%%s\n' \
+      printf -- '%%s/%%s:%%s\n' \
         \"${DOCKER_USER}\" \
         \"${DOCKER_IMAGE_NAME}\" \
         \"${DOCKER_IMAGE_TAG}\" \
@@ -155,7 +155,7 @@ ExecStart=/bin/bash -c \
           '^.+\.[0-9]+(\.[0-9]+)?$' \
           <<< %p.%i; \
       then \
-        /usr/bin/printf -- '--publish %%s%%s:22' \
+        printf -- '--publish %%s%%s:22' \
           $(\
             /bin/grep -o \
               '^[0-9\.]*:' \
@@ -175,7 +175,7 @@ ExecStart=/bin/bash -c \
             - 1 \
           )); \
       else \
-        /usr/bin/printf -- '--publish %%s:22' \
+        printf -- '--publish %%s:22' \
           \"${DOCKER_PORT_MAP_TCP_22}\"; \
       fi; \
     fi) \

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -2349,7 +2349,7 @@ function test_healthcheck ()
 						-v event_lag="${event_lag_seconds}" \
 						-v interval="${interval_seconds}" \
 						-v retries="${retries}" \
-						'BEGIN { print event_lag + (interval * retries); }'
+						'BEGIN { print (2 * event_lag) + (interval * retries); }'
 				)"
 
 				health_status="$(


### PR DESCRIPTION
CLOSES #762: 

- Fixes use of printf binary instead of builtin in systemd unit files.