### PR TITLE
CLOSES #786: Updates source image tag to 6.10.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 Summary of release changes for Version 1 - CentOS-6
 
-### 1.10.2 - Unreleased
+### 1.11.0 - Unreleased
 
+- Updates source image from `centos6.10` tag to `6.10`.
 - Updates supervisord to 3.4.0.
 - Updates default value of `SSH_AUTOSTART_SUPERVISOR_STDOUT` to false.
 - Updates `sshd-bootstrap` and `sshd-wrapper` configuration to send error log output to stderr.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:centos6.10
+FROM centos:6.10
 
 ARG RELEASE_VERSION="1.10.1"
 


### PR DESCRIPTION
CLOSES #786

- Updates source image from `centos6.10` tag to `6.10`.