### PR TITLE
CLOSES #793: Adds improved clean Makefile target.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,12 @@ Summary of release changes for Version 1 - CentOS-6
 - Adds reference to `python-setuptools` in README; removed in error.
 - Adds `inspect`, `reload` and `top` Makefile targets.
 - Adds improved lock/state file implementation in bootstrap and wrapper scripts.
+- Adds improved `clean` Makefile target; includes exited containers and dangling images.
 - Fixes port incrementation failures when installing systemd units via `scmi`.
 - Fixes etcd port registration failures when installing systemd units via `scmi` with the `--register` option.
 - Fixes binary paths in systemd unit files for compatibility with both EL and Ubuntu hosts.
 - Fixes use of printf binary instead of builtin in systemd unit files.
+- Fixes docker host connection status check in Makefile.
 - Removes support for long image tags (i.e. centos-6-1.x.x).
 
 ### 1.10.1 - 2019-02-28


### PR DESCRIPTION
CLOSES #793: Patches back #792 

- Adds improved `clean` Makefile target; includes exited containers and dangling images.
- Fixes docker host connection status check in Makefile.