### PR TITLE
CLOSES #802: Updates bootstrap timer to use UTC date timestamps.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Summary of release changes for Version 1 - CentOS-6
 - Updates default value of `ENABLE_SUPERVISOR_STDOUT` to false.
 - Updates `sshd-bootstrap` and `sshd-wrapper` configuration to send error log output to stderr.
 - Updates order of values in SSH/SFTP Details log output.
+- Updates bootstrap timer to use UTC date timestamps.
 - Adds reference to `python-setuptools` in README; removed in error.
 - Adds `inspect`, `reload` and `top` Makefile targets.
 - Adds improved lock/state file implementation in bootstrap and wrapper scripts.

--- a/src/usr/sbin/sshd-bootstrap
+++ b/src/usr/sbin/sshd-bootstrap
@@ -885,7 +885,7 @@ function __get_ssh_user_uid ()
 function __get_timer_total ()
 {
 	local -r timer_end="$(
-		date +%s.%N
+		date -u +%s.%N
 	)"
 	local -r timer_start="${1}"
 
@@ -1285,7 +1285,7 @@ function main ()
 	local -r redacted_value="********"
 	local -r state_file="/var/lib/misc/sshd-bootstrap"
 	local -r timer_start="$(
-		date +%s.%N
+		date -u +%s.%N
 	)"
 
 	local env


### PR DESCRIPTION
CLOSES #802

- Updates bootstrap timer to use UTC date timestamps.