### PR TITLE
CLOSES #818: Fixes make clean error thrown when removing exited containers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Summary of release changes for Version 2 - CentOS-7
 - Fixes binary paths in systemd unit files for compatibility with both EL and Ubuntu hosts.
 - Fixes use of printf binary instead of builtin in systemd unit files.
 - Fixes docker host connection status check in Makefile.
+- Fixes make clean error thrown when removing exited containers.
 - Removes support for long image tags (i.e. centos-7-2.x.x).
 - Removes system time zone setup from `sshd-bootstrap`.
 

--- a/Makefile
+++ b/Makefile
@@ -745,9 +745,9 @@ rm-exited: \
 			"$(PREFIX_STEP)" \
 			"Removing exited containers"; \
 		$(docker) rm -f \
-			"$$($(docker) ps -aq \
+			$$($(docker) ps -aq \
 				--filter "status=exited" \
-			)" \
+			) \
 			1> /dev/null; \
 	fi
 


### PR DESCRIPTION
CLOSES #818

- Fixes make clean error thrown when removing exited containers.